### PR TITLE
Add CustomResourceStateMetrics definitions for DNSZones and DNSRecordSets.

### DIFF
--- a/config/resource-metrics/dnsrecordsets.yaml
+++ b/config/resource-metrics/dnsrecordsets.yaml
@@ -1,0 +1,76 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: dns.networking.miloapis.com
+        kind: "DNSRecordSet"
+        version: "v1alpha1"
+      metricNamePrefix: dns_record_set
+      labelsFromPath:
+        name: [metadata, name]
+        namespace: [metadata, namespace]
+        dns_zone_name: [spec, dnsZoneRef, name]
+        record_type: [spec, recordType]
+      metrics:
+      - name: "owner"
+        help: "Owner information"
+        errorLogV: 10
+        each:
+          type: Info
+          info:
+            path: [metadata,ownerReferences]
+            labelsFromPath:
+              owner_kind: [kind]
+              owner_name: [name]
+              owner_uid: [uid]
+              controller: [controller]
+      - name: "info"
+        help: "DNSRecordSet information"
+        each:
+          type: Info
+          info:
+            labelsFromPath:
+              uid: [metadata, uid]
+      - name: "record_info"
+        help: "DNSRecordSet record information"
+        each:
+          type: Info
+          info:
+            path: [spec, records]
+            labelsFromPath:
+              record_name: [name]
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        errorLogV: 10
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+      - name: "status_condition"
+        help: "The current status conditions of the Domains"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              condition: [type]
+              reason: [reason]
+              status: [status]
+            valueFrom: [status]
+      - name: "status_condition_last_transition_time"
+        help: "last transition time for status conditions"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: [type]
+              reason: [reason]
+              status: [status]
+            valueFrom: [lastTransitionTime]

--- a/config/resource-metrics/dnszones.yaml
+++ b/config/resource-metrics/dnszones.yaml
@@ -1,0 +1,67 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+    - groupVersionKind:
+        group: dns.networking.miloapis.com
+        kind: "DNSZone"
+        version: "v1alpha1"
+      metricNamePrefix: dns_zone
+      labelsFromPath:
+        name: [metadata, name]
+        namespace: [metadata, namespace]
+      metrics:
+      - name: "owner"
+        help: "Owner information"
+        errorLogV: 10
+        each:
+          type: Info
+          info:
+            path: [metadata,ownerReferences]
+            labelsFromPath:
+              owner_kind: [kind]
+              owner_name: [name]
+              owner_uid: [uid]
+              controller: [controller]
+      - name: "info"
+        help: "DNSZone information"
+        each:
+          type: Info
+          info:
+            labelsFromPath:
+              uid: [metadata, uid]
+              domain_name: [spec, domainName]
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        errorLogV: 10
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+      - name: "status_condition"
+        help: "The current status conditions of the Domains"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              condition: [type]
+              reason: [reason]
+              status: [status]
+            valueFrom: [status]
+      - name: "status_condition_last_transition_time"
+        help: "last transition time for status conditions"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: [type]
+              reason: [reason]
+              status: [status]
+            valueFrom: [lastTransitionTime]

--- a/config/resource-metrics/kustomization.yaml
+++ b/config/resource-metrics/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+configMapGenerator:
+  - name: dns-operator-metrics
+    files:
+      - dnszones.yaml
+      - dnsrecordsets.yaml
+    options:
+      labels:
+        telemetry.miloapis.com/resource-metrics-config: "true"


### PR DESCRIPTION
These definitions will ultimately drive kube-state-metrics to produce metric series for DNS zones and record sets, as well as records within the recordsets.

<img width="2536" height="480" alt="image" src="https://github.com/user-attachments/assets/2d8ad9ff-93ef-4227-a287-091c79aa5749" />
