### PR TITLE
fix: translate raw PowerDNS errors into user-friendly status messages

### DIFF
--- a/internal/controller/dnsrecordset_powerdns_controller.go
+++ b/internal/controller/dnsrecordset_powerdns_controller.go
@@ -200,7 +200,7 @@ func (r *DNSRecordSetPowerDNSReconciler) setRecordProgrammedCondition(
 	case pdnsErr != nil:
 		newCond.Status = metav1.ConditionFalse
 		newCond.Reason = ReasonPDNSError
-		newCond.Message = pdnsErr.Error()
+		newCond.Message = pdnsclient.FriendlyMessage(pdnsErr)
 	default:
 		newCond.Status = metav1.ConditionTrue
 		newCond.Reason = ReasonProgrammed

--- a/internal/pdns/errors.go
+++ b/internal/pdns/errors.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package pdns
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+)
+
+// pdnsErrorBody is the JSON structure returned in PowerDNS API error responses.
+type pdnsErrorBody struct {
+	Error string `json:"error"`
+}
+
+// FriendlyMessage returns a user-readable message for a PowerDNS API error.
+// The raw technical error is preserved in operator logs; only the translated
+// message is written to the DNSRecordSet status condition so end users see
+// something actionable rather than internal API details.
+//
+// If err is not a *pdnsAPIError, a generic fallback message is returned.
+func FriendlyMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var apiErr *pdnsAPIError
+	if !errors.As(err, &apiErr) {
+		return "Failed to apply DNS record. It will be retried automatically."
+	}
+
+	// Extract the error field from the JSON body when present.
+	var body pdnsErrorBody
+	if apiErr.Body != "" {
+		_ = json.Unmarshal([]byte(apiErr.Body), &body)
+	}
+	detail := body.Error
+
+	switch {
+	case strings.Contains(detail, "Conflicts with pre-existing RRset"):
+		return "A conflicting record already exists for this name. Remove the existing record and try again."
+	case strings.Contains(detail, "Not in zone"):
+		return "The record name is outside the zone. Check that the name belongs to this DNS zone."
+	case strings.Contains(detail, "RRset") && strings.Contains(detail, "IN CNAME"):
+		return "A CNAME record conflicts with an existing record at this name."
+	case strings.Contains(detail, "RRset") && strings.Contains(detail, "IN ALIAS"):
+		return "An ALIAS record conflicts with an existing record at this name."
+	case apiErr.Status == 422:
+		return "The DNS record was rejected as invalid. Check the record type and value."
+	case apiErr.Status == 404:
+		return "The DNS zone could not be found. It may still be provisioning."
+	case apiErr.Status >= 500:
+		return "An internal error occurred while applying the record. It will be retried automatically."
+	default:
+		return "Failed to apply DNS record. It will be retried automatically."
+	}
+}

--- a/internal/pdns/errors_test.go
+++ b/internal/pdns/errors_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package pdns
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFriendlyMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error returns empty string",
+			err:  nil,
+			want: "",
+		},
+		{
+			name: "non-pdns error returns generic message",
+			err:  errors.New("some internal error"),
+			want: "Failed to apply DNS record. It will be retried automatically.",
+		},
+		{
+			name: "422 conflict with pre-existing RRset",
+			err:  &pdnsAPIError{Status: 422, Body: `{"error": "RRset www.example.com. IN ALIAS: Conflicts with pre-existing RRset"}`},
+			want: "A conflicting record already exists for this name. Remove the existing record and try again.",
+		},
+		{
+			name: "422 CNAME conflict",
+			err:  &pdnsAPIError{Status: 422, Body: `{"error": "RRset www.example.com. IN CNAME: Conflicts with pre-existing RRset"}`},
+			want: "A conflicting record already exists for this name. Remove the existing record and try again.",
+		},
+		{
+			name: "422 not in zone",
+			err:  &pdnsAPIError{Status: 422, Body: `{"error": "Not in zone"}`},
+			want: "The record name is outside the zone. Check that the name belongs to this DNS zone.",
+		},
+		{
+			name: "422 unknown body falls back to generic 422 message",
+			err:  &pdnsAPIError{Status: 422, Body: `{"error": "Some other validation error"}`},
+			want: "The DNS record was rejected as invalid. Check the record type and value.",
+		},
+		{
+			name: "404",
+			err:  &pdnsAPIError{Status: 404, Body: `{"error": "Not found"}`},
+			want: "The DNS zone could not be found. It may still be provisioning.",
+		},
+		{
+			name: "500",
+			err:  &pdnsAPIError{Status: 500, Body: "internal server error"},
+			want: "An internal error occurred while applying the record. It will be retried automatically.",
+		},
+		{
+			name: "503 is treated as a server error",
+			err:  &pdnsAPIError{Status: 503, Body: ""},
+			want: "An internal error occurred while applying the record. It will be retried automatically.",
+		},
+		{
+			name: "unexpected 4xx status code with no matching body",
+			err:  &pdnsAPIError{Status: 409, Body: ""},
+			want: "Failed to apply DNS record. It will be retried automatically.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FriendlyMessage(tt.err)
+			if got != tt.want {
+				t.Errorf("FriendlyMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Raw PowerDNS API errors (e.g. `status 422: {"error": "RRset www.kev1n.org. IN ALIAS: Conflicts with pre-existing RRset"}`) were written directly to the `Programmed` condition message on `DNSRecordSet` status, exposing internal HTTP/JSON details to end users.
- Add `pdns.FriendlyMessage(err error) string` which parses the error and returns an actionable message. The raw error is still logged by the controller for operator debugging.
- Use `FriendlyMessage` in `setRecordProgrammedCondition` instead of `pdnsErr.Error()`.

**Before:** `status 422: {"error": "RRset www.kev1n.org. IN ALIAS: Conflicts with pre-existing RRset"}`
**After:** `A conflicting record already exists for this name. Remove the existing record and try again.`

## Error mappings

| PowerDNS error | User message |
|---|---|
| Conflicts with pre-existing RRset | A conflicting record already exists for this name. Remove the existing record and try again. |
| Not in zone | The record name is outside the zone. Check that the name belongs to this DNS zone. |
| Generic 422 | The DNS record was rejected as invalid. Check the record type and value. |
| 404 | The DNS zone could not be found. It may still be provisioning. |
| 5xx | An internal error occurred while applying the record. It will be retried automatically. |

## Test plan

- [ ] `go test ./internal/pdns/...` passes (`TestFriendlyMessage` covers all mappings)
- [ ] `go build ./...` passes
- [ ] Manually create an AI Edge proxy for a hostname with an existing conflicting DNS record and confirm the status condition shows the friendly message