### PR TITLE
fix: add invalid character and empty body error message patterns

### DIFF
--- a/internal/pdns/errors.go
+++ b/internal/pdns/errors.go
@@ -39,6 +39,8 @@ func FriendlyMessage(err error) string {
 	switch {
 	case strings.Contains(detail, "Conflicts with pre-existing RRset"):
 		return "A conflicting record already exists for this name. Remove the existing record and try again."
+	case strings.Contains(detail, "Invalid character"):
+		return "The record content contains an invalid character. TXT records containing semicolons or special characters must be properly quoted."
 	case strings.Contains(detail, "Not in zone"):
 		return "The record name is outside the zone. Check that the name belongs to this DNS zone."
 	case strings.Contains(detail, "RRset") && strings.Contains(detail, "IN CNAME"):

--- a/internal/pdns/errors_test.go
+++ b/internal/pdns/errors_test.go
@@ -36,9 +36,19 @@ func TestFriendlyMessage(t *testing.T) {
 			want: "A conflicting record already exists for this name. Remove the existing record and try again.",
 		},
 		{
+			name: "422 invalid character in TXT record content",
+			err:  &pdnsAPIError{Status: 422, Body: `{"error": "Invalid character ';' in record content '\"=DMARC1; p=none; rua=mailto:admin@example.com\"'"}`},
+			want: "The record content contains an invalid character. TXT records containing semicolons or special characters must be properly quoted.",
+		},
+		{
 			name: "422 not in zone",
 			err:  &pdnsAPIError{Status: 422, Body: `{"error": "Not in zone"}`},
 			want: "The record name is outside the zone. Check that the name belongs to this DNS zone.",
+		},
+		{
+			name: "422 empty body falls back to generic 422 message",
+			err:  &pdnsAPIError{Status: 422, Body: ""},
+			want: "The DNS record was rejected as invalid. Check the record type and value.",
 		},
 		{
 			name: "422 unknown body falls back to generic 422 message",


### PR DESCRIPTION
## Summary

Follow-up to #32. Adds two missing error patterns to `pdns.FriendlyMessage`:

- **Invalid character in record content** — PowerDNS rejects TXT records where semicolons or other special characters are not properly escaped. Previously fell through to the generic 422 message. Now shows: `"The record content contains an invalid character. TXT records containing semicolons or special characters must be properly quoted."`
- **Empty body on 422** — adds an explicit test case for when the response body is empty, confirming the generic 422 fallback.

## Test plan

- [ ] `go test ./internal/pdns/... -run TestFriendlyMessage` passes
- [ ] Verify a DMARC/DKIM/SPF record with unescaped semicolons shows the specific error message