### PR TITLE
feat: add discovery context annotations for project-scoped resources

### DIFF
--- a/api/v1alpha1/dnsrecordset_types.go
+++ b/api/v1alpha1/dnsrecordset_types.go
@@ -228,6 +228,7 @@ type RecordSetStatus struct {
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=.status.conditions[?(@.type=="Programmed")].status
 // +kubebuilder:selectablefield:JSONPath=".spec.dnsZoneRef.name"
 // +kubebuilder:selectablefield:JSONPath=".spec.recordType"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"
 
 // DNSRecordSet is the Schema for the dnsrecordsets API
 type DNSRecordSet struct {

--- a/api/v1alpha1/dnszone_types.go
+++ b/api/v1alpha1/dnszone_types.go
@@ -61,6 +61,7 @@ type DNSZoneStatus struct {
 // +kubebuilder:printcolumn:name="Records",type=integer,JSONPath=.status.recordCount
 // +kubebuilder:selectablefield:JSONPath=".spec.domainName"
 // +kubebuilder:selectablefield:JSONPath=".status.domainRef.name"
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"
 
 // DNSZone is the Schema for the dnszones API
 type DNSZone struct {

--- a/api/v1alpha1/dnszoneclass_types.go
+++ b/api/v1alpha1/dnszoneclass_types.go
@@ -63,6 +63,7 @@ type DNSZoneClassStatus struct {
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="Accepted",type=string,JSONPath=.status.conditions[?(@.type=="Accepted")].status
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=.status.conditions[?(@.type=="Programmed")].status
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"
 
 // DNSZoneClass is the Schema for the dnszoneclasses API
 type DNSZoneClass struct {

--- a/api/v1alpha1/dnszonediscovery_types.go
+++ b/api/v1alpha1/dnszonediscovery_types.go
@@ -48,6 +48,7 @@ type DNSZoneDiscoveryStatus struct {
 // +kubebuilder:printcolumn:name="Discovered",type=string,JSONPath=.status.conditions[?(@.type=="Discovered")].status
 // +kubebuilder:selectablefield:JSONPath=".spec.dnsZoneRef.name"
 // +kubebuilder:resource:path=dnszonediscoveries,shortName=dnszd
+// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"
 
 // DNSZoneDiscovery is the Schema for the DNSZone discovery API.
 type DNSZoneDiscovery struct {

--- a/config/crd/bases/dns.networking.miloapis.com_dnsrecordsets.yaml
+++ b/config/crd/bases/dns.networking.miloapis.com_dnsrecordsets.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    discovery.miloapis.com/parent-contexts: Project
   name: dnsrecordsets.dns.networking.miloapis.com
 spec:
   group: dns.networking.miloapis.com

--- a/config/crd/bases/dns.networking.miloapis.com_dnszoneclasses.yaml
+++ b/config/crd/bases/dns.networking.miloapis.com_dnszoneclasses.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    discovery.miloapis.com/parent-contexts: Project
   name: dnszoneclasses.dns.networking.miloapis.com
 spec:
   group: dns.networking.miloapis.com

--- a/config/crd/bases/dns.networking.miloapis.com_dnszonediscoveries.yaml
+++ b/config/crd/bases/dns.networking.miloapis.com_dnszonediscoveries.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    discovery.miloapis.com/parent-contexts: Project
   name: dnszonediscoveries.dns.networking.miloapis.com
 spec:
   group: dns.networking.miloapis.com

--- a/config/crd/bases/dns.networking.miloapis.com_dnszones.yaml
+++ b/config/crd/bases/dns.networking.miloapis.com_dnszones.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    discovery.miloapis.com/parent-contexts: Project
   name: dnszones.dns.networking.miloapis.com
 spec:
   group: dns.networking.miloapis.com


### PR DESCRIPTION
## Summary

This PR adds `discovery.miloapis.com/parent-contexts: Project` annotations to all DNS CRD manifests and the corresponding `+kubebuilder:metadata:annotations` markers to all Go type definitions.

These annotations tell the Milo API server's discovery filter to only surface these resources when a client queries the API within a Project context (e.g., when connecting to a project's dedicated control plane). Without this annotation, resources appear in all discovery contexts, which clutters the API surface for non-project scopes.

## Affected CRDs

- `dnsrecordsets.dns.networking.miloapis.com` (DNSRecordSet)
- `dnszones.dns.networking.miloapis.com` (DNSZone)
- `dnszoneclasses.dns.networking.miloapis.com` (DNSZoneClass)
- `dnszonediscoveries.dns.networking.miloapis.com` (DNSZoneDiscovery)

## Changes

- Added `discovery.miloapis.com/parent-contexts: Project` to `metadata.annotations` in each CRD YAML under `config/crd/bases/`
- Added `// +kubebuilder:metadata:annotations="discovery.miloapis.com/parent-contexts=Project"` marker to each root Go type in `api/v1alpha1/`

## Test plan

- [ ] Verify CRD YAML files contain the `discovery.miloapis.com/parent-contexts: Project` annotation
- [ ] Verify Go types contain the `+kubebuilder:metadata:annotations` marker
- [ ] Deploy to a Milo-managed project control plane and confirm DNS resources appear in discovery only within the Project context
- [ ] Confirm DNS resources do not appear in Platform or Organization discovery contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)