### PR TITLE
fix: rename metrics RBAC to be operator-scoped

### DIFF
--- a/config/overlays/replicator/kustomization.yaml
+++ b/config/overlays/replicator/kustomization.yaml
@@ -27,7 +27,7 @@ patches:
   - path: patch-namespace.yaml
     target:
       kind: ClusterRoleBinding
-      name: metrics-auth-rolebinding
+      name: dns-operator-metrics-auth-rolebinding
   - path: patch-namespace.yaml
     target:
       kind: RoleBinding

--- a/config/rbac/metrics_auth_role.yaml
+++ b/config/rbac/metrics_auth_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-auth-role
+  name: dns-operator-metrics-auth-role
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/config/rbac/metrics_auth_role_binding.yaml
+++ b/config/rbac/metrics_auth_role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: metrics-auth-rolebinding
+  name: dns-operator-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: metrics-auth-role
+  name: dns-operator-metrics-auth-role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/config/rbac/metrics_reader_role.yaml
+++ b/config/rbac/metrics_reader_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-reader
+  name: dns-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - "/metrics"


### PR DESCRIPTION
## Summary

Renames the three cluster-scoped RBAC resources that kubebuilder generates with generic default names to use `dns-operator-` prefixed names:

- `ClusterRole/metrics-reader` → `ClusterRole/dns-operator-metrics-reader`
- `ClusterRole/metrics-auth-role` → `ClusterRole/dns-operator-metrics-auth-role`
- `ClusterRoleBinding/metrics-auth-rolebinding` → `ClusterRoleBinding/dns-operator-metrics-auth-rolebinding`

The `roleRef` in `metrics_auth_role_binding.yaml` and the target name in the replicator overlay's `kustomization.yaml` are updated to match.

## Problem

These generic names conflict with identically-named resources deployed by other operators (`compute-manager`, `fraud-rbac`), causing FluxCD ownership conflict alerts in staging because multiple Flux Kustomizations attempt to manage the same cluster-scoped objects.

## Testing

All four changed files build cleanly via `kubectl kustomize`. No Go code references these names.

Fixes #40