### PR TITLE
fix: repair e2e (Chainsaw) suite — kubeconfig port + fixtures + event reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,12 +188,19 @@ NSO_IMG ?= ghcr.io/datum-cloud/network-services-operator:latest
 NSO_NAMESPACE ?= network-services-operator-system
 NSO_DEPLOY ?= false
 
-# Host to rewrite kubeconfig servers for in-cluster access.
+# Host/port to rewrite kubeconfig servers for in-cluster access.
 # Defaults to the Docker network IP of the Kind control-plane container so the
 # kubeconfig is reachable from within other Kind pods (e.g. on GitHub Actions
 # Linux runners where host.docker.internal does not resolve). Override by
 # setting KIND_KUBECONFIG_HOST explicitly, e.g. for Docker Desktop on macOS.
 KIND_KUBECONFIG_HOST ?= $(shell docker inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(CLUSTER)-control-plane 2>/dev/null | head -1)
+# `kind get kubeconfig` reports the host-published port (a random port mapped
+# to the control-plane container). That port is only valid on the host; from
+# within the Docker network the API server listens on 6443. When we rewrite the
+# server to the container's network IP we must rewrite the port to 6443 too,
+# otherwise other Kind pods get "connection refused". Override alongside
+# KIND_KUBECONFIG_HOST if pointing at a host-published endpoint instead.
+KIND_KUBECONFIG_PORT ?= 6443
 
 .PHONY: kind-create
 kind-create: ## Create a kind cluster with name CLUSTER
@@ -232,8 +239,10 @@ export-kind-kubeconfig: ## Export kind kubeconfig for CLUSTER to OUT and rewrite
 	@test -n "$(OUT)" || { echo "OUT is required"; exit 1; }
 	@mkdir -p $(dir $(OUT))
 	$(KIND) get kubeconfig --name $(CLUSTER) > $(OUT).raw
-	# Replace server host with $(KIND_KUBECONFIG_HOST) to be reachable from other Docker containers
-	sed -E "s#(server:[[:space:]]*https://)[^:]+(:[0-9]+)#\1$(KIND_KUBECONFIG_HOST)\2#g" $(OUT).raw > $(OUT)
+	# Replace server host:port with $(KIND_KUBECONFIG_HOST):$(KIND_KUBECONFIG_PORT)
+	# so it is reachable from other Docker containers on the Kind network. The
+	# port must be the in-container API port (6443), not the host-published port.
+	sed -E "s#(server:[[:space:]]*https://)[^:]+:[0-9]+#\1$(KIND_KUBECONFIG_HOST):$(KIND_KUBECONFIG_PORT)#g" $(OUT).raw > $(OUT)
 	@if [ "$(KIND_KUBECONFIG_INSECURE)" = "true" ]; then \
 		echo "Rewriting kubeconfig to skip TLS verify (dev only)"; \
 		sed -E "s#^([[:space:]]*)certificate-authority-data:.*#\1insecure-skip-tls-verify: true#" $(OUT) > $(OUT).tmp; \

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -68,6 +68,13 @@ spec:
         image: ghcr.io/datum-cloud/dns-operator:latest
         imagePullPolicy: IfNotPresent
         name: manager
+        # POD_NAME is used as the reportingInstance on emitted events.k8s.io/v1
+        # Events, which the API server requires to be non-empty.
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         ports: []
         securityContext:
           readOnlyRootFilesystem: true

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -247,8 +247,29 @@ func buildEvent(
 		Note:                note,
 		Type:                eventType,
 		ReportingController: "dns.networking.miloapis.com/dns-operator",
-		ReportingInstance:   os.Getenv("POD_NAME"),
+		ReportingInstance:   reportingInstance(),
 	}
+}
+
+// reportingInstance returns a non-empty identifier for the reporting pod.
+// events.k8s.io/v1 requires reportingInstance to be set (1-128 chars), so we
+// fall back through POD_NAME -> hostname -> a constant when the downward-API
+// env var is unset (e.g. in tests or misconfigured deployments). The result is
+// truncated to the 128-character API limit.
+func reportingInstance() string {
+	name := os.Getenv("POD_NAME")
+	if name == "" {
+		if h, err := os.Hostname(); err == nil {
+			name = h
+		}
+	}
+	if name == "" {
+		name = "dns-operator"
+	}
+	if len(name) > 128 {
+		name = name[:128]
+	}
+	return name
 }
 
 // recordSetObjectRef builds a corev1.ObjectReference for a DNSRecordSet using

--- a/test/e2e/alias/chainsaw-test.yaml
+++ b/test/e2e/alias/chainsaw-test.yaml
@@ -120,11 +120,10 @@ spec:
           metadata:
             name: example-test
           status:
-            conditions:
-            - type: Accepted
-              status: "True"
-            - type: Programmed
-              status: "True"
+            (conditions[?type == 'Accepted']):
+            - status: "True"
+            (conditions[?type == 'Programmed']):
+            - status: "True"
 
   - name: Create ALIAS DNSRecordSet upstream (apex -> example.com)
     try:

--- a/test/e2e/alias/chainsaw-test.yaml
+++ b/test/e2e/alias/chainsaw-test.yaml
@@ -163,7 +163,7 @@ spec:
     - script:
         cluster: upstream
         content: |
-          set -euo pipefail
+          set -eu
           for i in $(seq 1 30); do
             acc="$(kubectl -n "$NAMESPACE" get dnsrecordset example-test-alias-apex -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null || true)"
             prog="$(kubectl -n "$NAMESPACE" get dnsrecordset example-test-alias-apex -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' 2>/dev/null || true)"
@@ -208,12 +208,12 @@ spec:
     - script:
         cluster: downstream
         content: |
-          set -euo pipefail
+          set -eu
           kubectl wait --for=condition=Ready --timeout=120s -n default pod/dnsutils-alias
           # ALIAS is provider-internal; clients query A/AAAA for the owner name.
           # Validate expansion by comparing A answers to a public resolver (dynamic, no hard-coded IPs).
           kubectl -n default exec pod/dnsutils-alias -- sh -lc '
-            set -euo pipefail
+            set -eu
             expected="$(dig @1.1.1.1 example.com A +short +tries=1 +time=2 | sort -u)"
             [ -n "$expected" ] || { echo "expected A set is empty" >&2; exit 1; }
             got="$(dig @pdns-auth.dns-agent-system.svc.cluster.local example.test A +short +tries=2 +time=2 | sort -u)"

--- a/test/e2e/display-annotations/chainsaw-test.yaml
+++ b/test/e2e/display-annotations/chainsaw-test.yaml
@@ -100,10 +100,12 @@ spec:
           kind: DNSZone
           metadata:
             name: annotations-test-zone
+          # The DNSZone carries both Accepted and Programmed conditions; assert
+          # only that the Accepted condition is True without requiring the slice
+          # to match exactly (a bare list would force a length match).
           status:
-            conditions:
-            - type: Accepted
-              status: "True"
+            (conditions[?type == 'Accepted']):
+            - status: "True"
 
   - name: Create DNSRecordSet upstream (A record)
     try:

--- a/test/e2e/display-annotations/chainsaw-test.yaml
+++ b/test/e2e/display-annotations/chainsaw-test.yaml
@@ -178,12 +178,14 @@ spec:
           kind: DNSRecordSet
           metadata:
             name: www-annotations-test
+          # Assert both conditions are True without depending on their order in
+          # the slice (chainsaw matches bare lists positionally; the DNSRecordSet
+          # emits them as [Programmed, Accepted]).
           status:
-            conditions:
-            - type: Accepted
-              status: "True"
-            - type: Programmed
-              status: "True"
+            (conditions[?type == 'Accepted']):
+            - status: "True"
+            (conditions[?type == 'Programmed']):
+            - status: "True"
 
   - name: Teardown - delete resources
     try:

--- a/test/e2e/zones-and-records/chainsaw-test.yaml
+++ b/test/e2e/zones-and-records/chainsaw-test.yaml
@@ -140,11 +140,10 @@ spec:
           # conditions and (in the next step) the DNSZoneClass-derived
           # nameservers.
           status:
-            conditions:
-            - type: Accepted
-              status: "True"
-            - type: Programmed
-              status: "True"
+            (conditions[?type == 'Accepted']):
+            - status: "True"
+            (conditions[?type == 'Programmed']):
+            - status: "True"
 
   - name: Assert upstream DNSZone nameservers
     try:
@@ -220,11 +219,10 @@ spec:
           metadata:
             name: www-example-com
           status:
-            conditions:
-            - type: Accepted
-              status: "True"
-            - type: Programmed
-              status: "True"
+            (conditions[?type == 'Accepted']):
+            - status: "True"
+            (conditions[?type == 'Programmed']):
+            - status: "True"
 
   - name: DNS queries from downstream to PDNS (SOA/NS/A)
     try:

--- a/test/e2e/zones-and-records/chainsaw-test.yaml
+++ b/test/e2e/zones-and-records/chainsaw-test.yaml
@@ -132,12 +132,14 @@ spec:
           kind: DNSZone
           metadata:
             name: example-com
+          # NOTE: status.domainRef.status.nameservers is mirrored from the
+          # upstream NSO Domain object's status, which is only populated when
+          # the Network Services Operator is deployed and resolving real
+          # external DNS. CI bootstraps without NSO (NSO_DEPLOY=false), so we
+          # assert only the fields this operator owns: the Accepted/Programmed
+          # conditions and (in the next step) the DNSZoneClass-derived
+          # nameservers.
           status:
-            domainRef:
-              status:
-                nameservers:
-                - hostname: elliott.ns.cloudflare.com
-                - hostname: hera.ns.cloudflare.com
             conditions:
             - type: Accepted
               status: "True"
@@ -255,7 +257,7 @@ spec:
     - script:
         cluster: downstream
         content: |
-          set -euo pipefail
+          set -eu
           # wait for pod ready condition
           kubectl wait --for=condition=Ready --timeout=120s -n default pod/dnsutils
           # Execute dig from inside the dnsutils pod (in-cluster DNS context)
@@ -287,7 +289,7 @@ spec:
     - script:
         cluster: upstream
         content: |
-          set -euo pipefail
+          set -eu
           # Confirm it no longer exists upstream
           if kubectl -n "$NAMESPACE" get dnsrecordset www-example-com >/dev/null 2>&1; then
             echo "upstream DNSRecordSet still exists" >&2
@@ -298,7 +300,7 @@ spec:
     - script:
         cluster: downstream
         content: |
-          set -euo pipefail
+          set -eu
           # verify A record no longer resolves
           kubectl -n default exec pod/dnsutils -- sh -lc '
           out=$(dig @pdns-auth.dns-agent-system.svc.cluster.local www.example.com A +short +tries=1 +time=1); 


### PR DESCRIPTION
## Summary

Fixes #46 — the E2E Tests (Chainsaw) suite has been red on `main` since 2026-05-01. Root cause was a kubeconfig port-rewrite bug; fixing it exposed three more pre-existing issues underneath. This PR addresses all of them to get the suite green.

## 1. kubeconfig in-network port (the blocker)

The replicator (upstream cluster) connects to the downstream cluster via a kubeconfig whose server host was rewritten to the control-plane's Docker-network IP (`da2b507`), but the **port** kept the value `kind get kubeconfig` reports — the **host-published** random port (e.g. `46671`). Inside the Docker network the API server listens on **6443**, so the watch failed:

```
failed to get informer from cache: ...dial tcp 172.18.0.2:46671: connect: connection refused
```

No informer → nothing replicated → every test timed out. Fix: rewrite the port to `6443` (the in-container API port; `KIND_KUBECONFIG_PORT`, overridable). Verified a container on the `kind` network reaches the rewritten `https://<ip>:6443/healthz` → HTTP 200.

## 2. NSO-dependent assertion (zones-and-records)

The test asserted `status.domainRef.status.nameservers` = real Cloudflare NS, a field mirrored from the NSO `Domain` status. CI bootstraps without NSO (`NSO_DEPLOY=false`). Now asserts only operator-owned fields (Accepted/Programmed conditions + the DNSZoneClass-derived `status.nameservers`).

## 3. Strict conditions-slice match (display-annotations)

Asserted a single-element `conditions` list while the DNSZone carries two (Accepted+Programmed) → "lengths of slices don't match". Switched to a JMESPath filter asserting only the Accepted condition.

## 4. dash vs `set -o pipefail` (alias, zones-and-records)

Chainsaw runs `script` blocks under `/usr/bin/sh` (dash on CI), which rejects `-o pipefail` (`sh: 1: set: Illegal option -o pipefail`) — the script died on line 1 even though the ALIAS recordset reached `Programmed=True`. Changed to `set -eu`.

## 5. Empty reportingInstance rejected (real config bug)

`events.k8s.io/v1` requires a non-empty `reportingInstance`, but `POD_NAME` was never injected, so every emitted activity Event was rejected (currently swallowed, but events never reach the API server in prod either). Inject `POD_NAME` via the downward API on the replicator Deployment, plus a hostname fallback in `buildEvent`.

## Verification

- [x] kubeconfig rewrite produces `https://<ip>:6443`; reachable from a container on the `kind` network (HTTP 200)
- [x] `go build ./...` and event unit tests pass; `POD_NAME` renders in the replicator overlay
- [x] E2E Tests workflow green on this PR (the real proof)