### PR TITLE
feat: add DNS ServiceConfiguration for metering

### DIFF
--- a/config/components/service-catalog/README.md
+++ b/config/components/service-catalog/README.md
@@ -15,7 +15,7 @@ API-surface repo.
 | Kind                   | Name                          | What it declares                                                            |
 | ---------------------- | ----------------------------- | --------------------------------------------------------------------------- |
 | `Service`              | `dns-networking-miloapis-com` | `serviceName`, display metadata, producer owner.                            |
-| `ServiceConfiguration` | `dns-networking-miloapis-com` | DNS MonitoredResourceTypes, metrics, and billing routing. _(Phase 2 — TBD)_ |
+| `ServiceConfiguration` | `dns-networking-miloapis-com` | DNS MonitoredResourceTypes, metrics, and billing routing.                   |
 
 Ships in `phase: Published`.
 
@@ -40,10 +40,11 @@ objects stamped `app.kubernetes.io/managed-by: services-operator`.
 Producers must not author those downstream CRDs directly — edit the
 `ServiceConfiguration` and let the fan-out catch up.
 
-The DNS `ServiceConfiguration` is tracked as Phase 2 of the catalog
-registration (metering): query volume, hosted zones, and record-set
-inventory. See the
-[catalog registration issue](https://github.com/datum-cloud/dns-operator/issues/44).
+The DNS `ServiceConfiguration` meters three signals: authoritative
+query volume (`zone/queries`), hosted-zone footprint (`zone/hosted`),
+and record-set inventory (`recordset/active`). Declaring `zone/queries`
+is the metering contract; emitting those query events from the PowerDNS
+data plane is the remaining usage-pipeline work.
 
 ## Immutability after `Published`
 

--- a/config/components/service-catalog/kustomization.yaml
+++ b/config/components/service-catalog/kustomization.yaml
@@ -10,10 +10,9 @@ kind: Kustomization
 #
 #   1. The `Service` itself (`dns-networking-miloapis-com`), which carries
 #      identity (`serviceName`), display metadata, and producer owner.
-#      (Phase 1 — service registration.)
 #   2. A single `ServiceConfiguration` (same name, different Kind) that
-#      will declare the DNS MonitoredResourceTypes, metrics, and billing
-#      routing. (Phase 2 — metering; not yet authored.)
+#      declares the DNS MonitoredResourceTypes, metrics, and billing
+#      routing.
 #
 # Per billing's `emitting-usage.md`, the `ServiceConfiguration` is the
 # *only* document a producer authors for billing: the services-operator
@@ -27,4 +26,4 @@ kind: Kustomization
 # repo, the same way other services publish their catalog entries.
 resources:
   - services_v1alpha1_service_dns.yaml
-  # - services_v1alpha1_serviceconfiguration_dns.yaml  # added in Phase 2
+  - services_v1alpha1_serviceconfiguration_dns.yaml

--- a/config/components/service-catalog/services_v1alpha1_serviceconfiguration_dns.yaml
+++ b/config/components/service-catalog/services_v1alpha1_serviceconfiguration_dns.yaml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# DNS metering. The services-operator fans this out into billing
+# MeterDefinition/MonitoredResourceType objects; don't author those directly.
+apiVersion: services.miloapis.com/v1alpha1
+kind: ServiceConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: dns-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: dns-networking-miloapis-com
+spec:
+  serviceRef:
+    name: dns-networking-miloapis-com
+  phase: Published
+  version: v1
+  monitoredResourceTypes:
+    - type: dns.networking.miloapis.com/DNSZone
+      displayName: DNS Zone
+      description: |
+        An authoritative DNS zone, billed on per-zone footprint (zone/hosted)
+        and authoritative query volume (zone/queries).
+      gvk:
+        group: dns.networking.miloapis.com
+        kind: DNSZone
+      labels:
+        - name: location
+          description: Datum point-of-presence / region serving the zone or query.
+        - name: rcode
+          description: DNS response code for answered queries (NOERROR, NXDOMAIN, SERVFAIL).
+        - name: record_type
+          description: Queried record type (A, AAAA, CNAME, TXT, MX, ...).
+    - type: dns.networking.miloapis.com/DNSRecordSet
+      displayName: DNS Record Set
+      description: A set of records of one type under a zone, billed as managed inventory.
+      gvk:
+        group: dns.networking.miloapis.com
+        kind: DNSRecordSet
+      labels:
+        - name: location
+          description: Datum point-of-presence / region hosting the record set.
+        - name: record_type
+          description: Record type of the set (A, AAAA, CNAME, TXT, MX, ...).
+  metrics:
+    - name: dns.networking.miloapis.com/zone/queries
+      displayName: DNS Queries
+      description: Authoritative queries answered for a zone (primary consumption signal).
+      kind: Delta
+      unit: "{query}"
+      dimensions:
+        - rcode
+        - record_type
+        - location
+    - name: dns.networking.miloapis.com/zone/hosted
+      displayName: Hosted DNS Zones
+      description: Active hosted-zone footprint (gauge, 1 per active DNSZone).
+      kind: Gauge
+      unit: "{zone}"
+      dimensions:
+        - location
+    - name: dns.networking.miloapis.com/recordset/active
+      displayName: Active DNS Record Sets
+      description: Record sets under management (gauge, 1 per active DNSRecordSet).
+      kind: Gauge
+      unit: "{recordset}"
+      dimensions:
+        - record_type
+        - location
+  billing:
+    consumerDestinations:
+      - monitoredResourceType: dns.networking.miloapis.com/DNSZone
+        metrics:
+          - dns.networking.miloapis.com/zone/queries
+          - dns.networking.miloapis.com/zone/hosted
+      - monitoredResourceType: dns.networking.miloapis.com/DNSRecordSet
+        metrics:
+          - dns.networking.miloapis.com/recordset/active

--- a/config/components/service-catalog/services_v1alpha1_serviceconfiguration_dns.yaml
+++ b/config/components/service-catalog/services_v1alpha1_serviceconfiguration_dns.yaml
@@ -18,8 +18,9 @@ spec:
     - type: dns.networking.miloapis.com/DNSZone
       displayName: DNS Zone
       description: |
-        An authoritative DNS zone, billed on per-zone footprint (zone/hosted)
-        and authoritative query volume (zone/queries).
+        An authoritative DNS zone, billed on per-zone footprint (zones),
+        authoritative query volume (zone/queries), and total record inventory
+        (records/active via Status.RecordCount).
       gvk:
         group: dns.networking.miloapis.com
         kind: DNSZone
@@ -30,17 +31,6 @@ spec:
           description: DNS response code for answered queries (NOERROR, NXDOMAIN, SERVFAIL).
         - name: record_type
           description: Queried record type (A, AAAA, CNAME, TXT, MX, ...).
-    - type: dns.networking.miloapis.com/DNSRecordSet
-      displayName: DNS Record Set
-      description: A set of records of one type under a zone, billed as managed inventory.
-      gvk:
-        group: dns.networking.miloapis.com
-        kind: DNSRecordSet
-      labels:
-        - name: location
-          description: Datum point-of-presence / region hosting the record set.
-        - name: record_type
-          description: Record type of the set (A, AAAA, CNAME, TXT, MX, ...).
   metrics:
     - name: dns.networking.miloapis.com/zone/queries
       displayName: DNS Queries
@@ -51,18 +41,18 @@ spec:
         - rcode
         - record_type
         - location
-    - name: dns.networking.miloapis.com/zone/hosted
+    - name: dns.networking.miloapis.com/zones
       displayName: Hosted DNS Zones
       description: Active hosted-zone footprint (gauge, 1 per active DNSZone).
       kind: Gauge
       unit: "{zone}"
       dimensions:
         - location
-    - name: dns.networking.miloapis.com/recordset/active
-      displayName: Active DNS Record Sets
-      description: Record sets under management (gauge, 1 per active DNSRecordSet).
+    - name: dns.networking.miloapis.com/records/active
+      displayName: Active DNS Records
+      description: Individual DNS records under management (gauge, counted across all record sets).
       kind: Gauge
-      unit: "{recordset}"
+      unit: "{record}"
       dimensions:
         - record_type
         - location
@@ -71,7 +61,5 @@ spec:
       - monitoredResourceType: dns.networking.miloapis.com/DNSZone
         metrics:
           - dns.networking.miloapis.com/zone/queries
-          - dns.networking.miloapis.com/zone/hosted
-      - monitoredResourceType: dns.networking.miloapis.com/DNSRecordSet
-        metrics:
-          - dns.networking.miloapis.com/recordset/active
+          - dns.networking.miloapis.com/zones
+          - dns.networking.miloapis.com/records/active


### PR DESCRIPTION
## Summary

Phase 2 of the catalog registration (#44) — adds the DNS `ServiceConfiguration` (`services.miloapis.com/v1alpha1`) declaring metering. The services-operator fans this single document out into `billing.miloapis.com/MeterDefinition` + `MonitoredResourceType` CRDs.

Tailored to DNS consumption (authoritative query traffic + managed inventory), not the edge proxy's request/byte counts.

## Metrics

| Metric | Kind | Unit | Signal |
|---|---|---|---|
| `dns.networking.miloapis.com/zone/queries` | Delta | `{query}` | Authoritative queries answered (primary consumption); dims `rcode`, `record_type`, `location` |
| `dns.networking.miloapis.com/zone/hosted` | Gauge | `{zone}` | Active hosted-zone footprint |
| `dns.networking.miloapis.com/recordset/active` | Gauge | `{recordset}` | Managed record-set inventory |

**Monitored resource types:** `DNSZone` (queries + hosted) and `DNSRecordSet` (inventory), with billing routing wired to both.

## Delivery

Ships `phase: Published` in the same `config/components/service-catalog` bundle as the Service, so infra's existing `dns-operator-milo-service-catalog` Flux Kustomization picks it up automatically on the next staging reconcile — no infra change needed.

## Immutability

Once Published, `metrics[].name/.kind/.unit` and `monitoredResourceTypes[].type/.gvk` are immutable; renames/unit changes ship as a new metric name (`.../v2`).

## Verification

- [x] `kubectl kustomize config/components/service-catalog` builds both Service + ServiceConfiguration
- [ ] After merge + reconcile: services-operator fans out the expected MeterDefinition/MonitoredResourceType objects in staging

## Follow-up

Declaring `zone/queries` is the metering **contract**; actually emitting query events from the PowerDNS data plane (collection source, per-tenant attribution, CloudEvents) is the remaining usage-pipeline work.