### PR TITLE
fix: show DNS record changes in the activity feed

### DIFF
--- a/config/milo/activity/policies/dnsrecordset-policy.yaml
+++ b/config/milo/activity/policies/dnsrecordset-policy.yaml
@@ -49,43 +49,43 @@ spec:
     # ----- CREATE RULES (type-specific with display annotations) -----
     # A/AAAA records with display annotations: "added www.example.com pointing to 192.0.2.10"
     - name: create-a-aaaa
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType in ['A', 'AAAA'] && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType) && audit.requestObject.spec.recordType in ['A', 'AAAA'] && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && 'dns.networking.miloapis.com/display-value' in audit.responseObject.metadata.annotations"
       summary: "{{ actor }} added {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} pointing to {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     # CNAME records with display annotations: "added api.example.com as an alias for api.internal.example.com"
     - name: create-cname
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'CNAME' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType) && audit.requestObject.spec.recordType == 'CNAME' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && 'dns.networking.miloapis.com/display-value' in audit.responseObject.metadata.annotations"
       summary: "{{ actor }} added {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} as an alias for {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     # ALIAS records with display annotations: "added example.com as an alias for lb.example.com"
     - name: create-alias
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'ALIAS' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType) && audit.requestObject.spec.recordType == 'ALIAS' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && 'dns.networking.miloapis.com/display-value' in audit.responseObject.metadata.annotations"
       summary: "{{ actor }} added {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} as an alias for {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     # MX records with display annotations: "configured mail for example.com using 10 mail.example.com"
     - name: create-mx
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'MX' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType) && audit.requestObject.spec.recordType == 'MX' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && 'dns.networking.miloapis.com/display-value' in audit.responseObject.metadata.annotations"
       summary: "{{ actor }} configured mail for {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} using {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     # TXT records with display annotations: "added TXT record for example.com"
     - name: create-txt
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'TXT' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType) && audit.requestObject.spec.recordType == 'TXT' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
       summary: "{{ actor }} added a TXT record for {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }}"
 
     # NS records with display annotations: "added nameservers for sub.example.com"
     - name: create-ns
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'NS' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType) && audit.requestObject.spec.recordType == 'NS' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
       summary: "{{ actor }} added nameservers for {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }}"
 
     # Generic create with display annotations: "added SRV record for _sip._tcp.example.com"
     - name: create-other-annotated
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType)"
       summary: "{{ actor }} added a {{ audit.requestObject.spec.recordType }} record for {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }}"
 
     # Create with audit.requestObject.spec but no display annotations: "added an A record"
     # Uses audit.requestObject.spec which is available at Request audit level and above.
     - name: create-from-request
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType)"
       summary: "{{ actor }} added {{ link('a ' + audit.requestObject.spec.recordType + ' record', audit.objectRef) }}"
 
     # Create last resort (no spec available at all): "added a DNS record"
@@ -101,7 +101,7 @@ spec:
 
     # Delete with audit.responseObject.spec available: "removed an A record"
     - name: delete-from-response
-      match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete' && has(audit.responseObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb == 'delete' && has(audit.responseObject.spec) && has(audit.responseObject.spec.recordType)"
       summary: "{{ actor }} removed {{ link('a ' + audit.responseObject.spec.recordType + ' record', audit.objectRef) }}"
 
     # Delete last resort: "removed a DNS record"
@@ -112,22 +112,22 @@ spec:
     # ----- UPDATE RULES (type-specific with display annotations) -----
     # A/AAAA records with display annotations: "updated www.example.com to point to 192.0.2.20"
     - name: update-a-aaaa
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && audit.requestObject.spec.recordType in ['A', 'AAAA'] && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType) && audit.requestObject.spec.recordType in ['A', 'AAAA'] && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && 'dns.networking.miloapis.com/display-value' in audit.responseObject.metadata.annotations"
       summary: "{{ actor }} updated {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} to point to {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     # CNAME records with display annotations: "updated api.example.com to alias api.v2.example.com"
     - name: update-cname
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'CNAME' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType) && audit.requestObject.spec.recordType == 'CNAME' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && 'dns.networking.miloapis.com/display-value' in audit.responseObject.metadata.annotations"
       summary: "{{ actor }} updated {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} to alias {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     # Generic update with display annotations
     - name: update-other-annotated
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType)"
       summary: "{{ actor }} updated {{ audit.requestObject.spec.recordType }} record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }}"
 
     # Update with audit.requestObject.spec but no display annotations: "updated an A record"
     - name: update-from-request
-      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec)"
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType)"
       summary: "{{ actor }} updated {{ link('a ' + audit.requestObject.spec.recordType + ' record', audit.objectRef) }}"
 
     # Update last resort: "updated a DNS record"
@@ -138,12 +138,12 @@ spec:
     # ----- SYSTEM CREATE RULES -----
     # System-created records (SOA, NS) with display annotations
     - name: system-create-annotated
-      match: "audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && has(audit.requestObject.spec)"
+      match: "audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType)"
       summary: "Default {{ audit.requestObject.spec.recordType }} record created for {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }}"
 
     # System-created records with spec but no display annotations
     - name: system-create-from-request
-      match: "audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec)"
+      match: "audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && has(audit.requestObject.spec.recordType)"
       summary: "Default {{ audit.requestObject.spec.recordType }} record created for {{ link(audit.objectRef.name, audit.objectRef) }}"
 
   # Event rules for controller-emitted Kubernetes events.


### PR DESCRIPTION
## What this does

Adding or changing a DNS record should show up in your activity feed. For some records that entry was quietly going missing. This makes DNS changes show up reliably — and when a friendly label isn't available, it gracefully falls back to a simple, still-useful description instead of dropping the entry entirely.

## What changed

- Summaries now use optional details (like a display label or the record type) only when they're actually present, and fall back to a clear generic message otherwise.
- No user-facing wording changed — this just stops entries from being dropped.

