### PR TITLE
fix: surface specific PowerDNS 422 detail in DNSRecordSet status

### DIFF
--- a/internal/pdns/errors.go
+++ b/internal/pdns/errors.go
@@ -48,6 +48,11 @@ func FriendlyMessage(err error) string {
 	case strings.Contains(detail, "RRset") && strings.Contains(detail, "IN ALIAS"):
 		return "An ALIAS record conflicts with an existing record at this name."
 	case apiErr.Status == 422:
+		// Surface the specific PowerDNS rejection reason when it doesn't match a
+		// known pattern; without it the reason is only visible in operator logs.
+		if detail != "" {
+			return "The DNS record was rejected as invalid: " + detail
+		}
 		return "The DNS record was rejected as invalid. Check the record type and value."
 	case apiErr.Status == 404:
 		return "The DNS zone could not be found. It may still be provisioning."

--- a/internal/pdns/errors_test.go
+++ b/internal/pdns/errors_test.go
@@ -51,9 +51,9 @@ func TestFriendlyMessage(t *testing.T) {
 			want: "The DNS record was rejected as invalid. Check the record type and value.",
 		},
 		{
-			name: "422 unknown body falls back to generic 422 message",
+			name: "422 unknown body surfaces the specific pdns detail",
 			err:  &pdnsAPIError{Status: 422, Body: `{"error": "Some other validation error"}`},
-			want: "The DNS record was rejected as invalid. Check the record type and value.",
+			want: "The DNS record was rejected as invalid: Some other validation error",
 		},
 		{
 			name: "404",


### PR DESCRIPTION
## What

When PowerDNS rejects a PATCH with a 422 whose `error` field doesn't match one of the curated patterns, `FriendlyMessage` collapsed it into a generic `"The DNS record was rejected as invalid. Check the record type and value."`, dropping the specific pdns reason. The detail survived only in the operator pod logs (`logger.Error(pdnsErr, "pdns apply failed")`), so `kubectl get dnsrecordset -o yaml` showed nothing actionable.

This appends the specific pdns detail to the generic 422 fallback:

```
The DNS record was rejected as invalid: <pdns error detail>
```

## Why

Surfaced while diagnosing #51 (fleet-wide prod 422s on `PATCH /zones`). The whole investigation stalled on "we can't see the rejection reason", but the reason was being thrown away at the status layer, not unavailable. With this change, future pdns validation regressions are diagnosable from the CR status without pod-log access.

## Scope

- Only the **generic 422 fallback** changes. Curated actionable messages (`Invalid character`, `Not in zone`, `Conflicts with pre-existing RRset`, CNAME/ALIAS conflicts) are unchanged.
- The empty-body 422 case still returns the generic message (nothing to append).
- No behavior change for 404, 5xx, or non-pdns errors.

## Test

`internal/pdns/errors_test.go`: the "unknown 422 body" case now asserts the detail is surfaced. `go test ./internal/pdns/ -run TestFriendlyMessage` passes. The package's Docker/testcontainers integration test is unrelated and not run here.

Refs #51
