### PR TITLE
fix: dedupe RRset records before PowerDNS PATCH

### DIFF
--- a/internal/controller/dnszone_helpers.go
+++ b/internal/controller/dnszone_helpers.go
@@ -13,7 +13,15 @@ func normalizeStringSlice(in []string) []string {
 	if len(in) == 0 {
 		return nil
 	}
-	out := append([]string(nil), in...)
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
 	sort.Strings(out)
 	return out
 }
@@ -31,16 +39,22 @@ func normalizeDomainNameservers(in []networkingv1alpha.Nameserver) []networkingv
 	if len(in) == 0 {
 		return nil
 	}
-	out := make([]networkingv1alpha.Nameserver, len(in))
+	seen := make(map[string]struct{}, len(in))
+	out := make([]networkingv1alpha.Nameserver, 0, len(in))
 	for i := range in {
-		out[i] = in[i]
-		if len(out[i].IPs) > 0 {
-			ips := append([]networkingv1alpha.NameserverIP(nil), out[i].IPs...)
+		if _, ok := seen[in[i].Hostname]; ok {
+			continue
+		}
+		seen[in[i].Hostname] = struct{}{}
+		ns := in[i]
+		if len(ns.IPs) > 0 {
+			ips := append([]networkingv1alpha.NameserverIP(nil), ns.IPs...)
 			sort.Slice(ips, func(a, b int) bool {
 				return ips[a].Address < ips[b].Address
 			})
-			out[i].IPs = ips
+			ns.IPs = ips
 		}
+		out = append(out, ns)
 	}
 	sort.Slice(out, func(a, b int) bool {
 		return out[a].Hostname < out[b].Hostname

--- a/internal/controller/dnszone_helpers_test.go
+++ b/internal/controller/dnszone_helpers_test.go
@@ -28,6 +28,13 @@ func TestNormalizeStringSlice(t *testing.T) {
 	if reflect.DeepEqual(in, want) {
 		t.Fatalf("expected input slice to remain unsorted")
 	}
+
+	// Duplicates are collapsed (duplicate nameservers previously produced a
+	// duplicate-record RRset that PowerDNS rejected with HTTP 422).
+	dup := []string{"ns2", "ns1", "ns2", "ns1"}
+	if got := normalizeStringSlice(dup); !reflect.DeepEqual(got, []string{"ns1", "ns2"}) {
+		t.Fatalf("expected duplicates removed, got=%v", got)
+	}
 }
 
 func TestNormalizeDomainNameservers(t *testing.T) {
@@ -69,6 +76,15 @@ func TestNormalizeDomainNameservers(t *testing.T) {
 	// Ensure input not mutated
 	if reflect.DeepEqual(in, want) {
 		t.Fatalf("expected input slice to remain unsorted")
+	}
+
+	// Nameservers with a duplicate hostname collapse to one entry.
+	dup := []networkingv1alpha.Nameserver{
+		{Hostname: "ns1.example.com", IPs: []networkingv1alpha.NameserverIP{{Address: "192.0.2.5"}}},
+		{Hostname: "ns1.example.com", IPs: []networkingv1alpha.NameserverIP{{Address: "192.0.2.5"}}},
+	}
+	if got := normalizeDomainNameservers(dup); len(got) != 1 || got[0].Hostname != "ns1.example.com" {
+		t.Fatalf("expected duplicate hostname collapsed, got=%v", got)
 	}
 }
 

--- a/internal/pdns/client.go
+++ b/internal/pdns/client.go
@@ -352,7 +352,7 @@ func (c *Client) ReplaceRRSet(
 		Type:       recordType,
 		TTL:        ttl,
 		ChangeType: "REPLACE",
-		Records:    records,
+		Records:    dedupeRecords(records),
 	}}
 	return c.applyRRSetPatch(ctx, zone, patch)
 }
@@ -619,7 +619,29 @@ func buildRRSets(zone string, rs dnsv1alpha1.DNSRecordSet) []rrset {
 	}
 	sort.Strings(owners)
 	for _, owner := range owners {
-		out = append(out, *setsByOwner[owner])
+		r := setsByOwner[owner]
+		r.Records = dedupeRecords(r.Records)
+		out = append(out, *r)
+	}
+	return out
+}
+
+// dedupeRecords removes records with duplicate Content within a single RRset,
+// preserving first-seen order. PowerDNS rejects the whole RRset with HTTP 422
+// ("duplicate record with content ...") if the same content appears twice, so
+// the payload must be de-duplicated before it is sent.
+func dedupeRecords(in []rrsetRecord) []rrsetRecord {
+	if len(in) < 2 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := in[:0]
+	for _, rec := range in {
+		if _, ok := seen[rec.Content]; ok {
+			continue
+		}
+		seen[rec.Content] = struct{}{}
+		out = append(out, rec)
 	}
 	return out
 }

--- a/internal/pdns/pdns_test.go
+++ b/internal/pdns/pdns_test.go
@@ -685,3 +685,46 @@ func TestMakeSimpleRRSet(t *testing.T) {
 		t.Fatalf("unexpected rrset: %#v", rr)
 	}
 }
+
+func TestBuildRRSets_DeduplicatesRecords(t *testing.T) {
+	t.Parallel()
+
+	// Duplicate NS content on one owner (regression: PowerDNS 422 "duplicate
+	// record with content ..." rejected the whole RRset, blocking every zone).
+	rsNS := dnsv1alpha1.DNSRecordSet{
+		Spec: dnsv1alpha1.DNSRecordSetSpec{
+			RecordType: dnsv1alpha1.RRTypeNS,
+			Records: []dnsv1alpha1.RecordEntry{
+				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns1.datumdns.net"}},
+				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns1.datumdns.net"}},
+				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns2.datumdns.net"}},
+				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns1.datumdns.net"}},
+			},
+		},
+	}
+	rr := buildRRSets("example.com", rsNS)
+	if len(rr) != 1 {
+		t.Fatalf("expected 1 rrset, got %d: %#v", len(rr), rr)
+	}
+	if got := len(rr[0].Records); got != 2 {
+		t.Fatalf("expected NS records deduped to 2, got %d: %#v", got, rr[0].Records)
+	}
+	if rr[0].Records[0].Content != "ns1.datumdns.net." || rr[0].Records[1].Content != "ns2.datumdns.net." {
+		t.Fatalf("expected first-seen order preserved, got %#v", rr[0].Records)
+	}
+
+	// Duplicate CNAME content collapses to a single record (CNAME is single-valued).
+	rsCNAME := dnsv1alpha1.DNSRecordSet{
+		Spec: dnsv1alpha1.DNSRecordSetSpec{
+			RecordType: dnsv1alpha1.RRTypeCNAME,
+			Records: []dnsv1alpha1.RecordEntry{
+				{Name: "www", CNAME: &dnsv1alpha1.CNAMERecordSpec{Content: "target.example.net."}},
+				{Name: "www", CNAME: &dnsv1alpha1.CNAMERecordSpec{Content: "target.example.net."}},
+			},
+		},
+	}
+	rr = buildRRSets("example.com", rsCNAME)
+	if len(rr) != 1 || len(rr[0].Records) != 1 || rr[0].Records[0].Content != "target.example.net." {
+		t.Fatalf("expected CNAME deduped to single record, got %#v", rr)
+	}
+}


### PR DESCRIPTION
## What

PowerDNS rejects a zone `PATCH` with **HTTP 422** when an RRset contains
duplicate record content (`duplicate record with content ...`, and for
single-valued types `only one such record allowed`). The downstream agent was
sending such payloads, so affected DNSZones never reached
`Accepted`/`Programmed`. Fixes #51.

Captured live from prod (`dns-operator-agent-pdns-auth-0 -c manager`):

```json
{"error": "Multiple errors found in RRset", "errors": [
  "RRset estate-buddy.com. IN NS: duplicate record with content \"ns1.datumdns.net\"",
  "RRset estate-buddy.com. IN NS: duplicate record with content \"ns2.datumdns.net\"",
  "RRset estate-buddy.com. IN NS: duplicate record with content \"ns3.datumdns.net\"",
  "RRset estate-buddy.com. IN NS: duplicate record with content \"ns4.datumdns.net\""
]}
```

The most common trigger was the **default NS RRset**, whose nameservers arrived
duplicated in the upstream DNSZone status. That failed on **every** newly-created
zone — including the infra Integration Chainsaw `dns-setup` test, which has been
red since ~2026-07-03.

## Changes

Fix at both the source and the payload boundary (defense in depth):

- **`buildRRSets` / `ReplaceRRSet`** (`internal/pdns/client.go`) — dedupe records
  by content within each RRset (first-seen order preserved) before the PATCH. A
  universal backstop that keeps the operator robust to duplicate content of any
  record type.
- **`normalizeStringSlice` / `normalizeDomainNameservers`**
  (`internal/controller/dnszone_helpers.go`) — drop duplicates (they already
  sorted), so duplicate nameservers no longer pollute DNSZone status or the
  generated default NS DNSRecordSet.
- Unit tests: NS/CNAME dedupe in `buildRRSets`, duplicate collapsing in the
  normalize helpers.

## Test

```
go test ./internal/pdns/ -run 'TestBuildRRSets|TestReplace|TestApplyRecordSet'   # PASS
go test ./internal/controller/ -run 'TestNormalize...'                           # PASS
go build ./... ; go vet ./internal/pdns/ ./internal/controller/                  # clean
```

(The `TestControllers` envtest suite requires a local etcd/kube-apiserver binary
not present in my environment — unrelated to this change.)

## Not covered here (follow-ups)

- **ALIAS `Conflicts with pre-existing RRset`** (Mode 3 in #51) — a distinct
  semantic issue (ALIAS coexisting with another RRset at the same name), seen
  only on the demo/import zones, not the Chainsaw path. Worth a separate change.
- **Surface the pdns `error` string into the DNSRecordSet status condition**
  instead of collapsing all 422s to the generic `FriendlyMessage`
  (`internal/pdns/errors.go`) — this incident was invisible via
  `kubectl get dnsrecordset -o yaml` because the detail only reached the logs.

Refs #51 (does not fully close it — the ALIAS-conflict follow-up above remains).
