### PR TITLE
fix: dedupe nameservers to stop duplicate-NS 422 on new zones

### DIFF
--- a/internal/controller/dnszone_helpers.go
+++ b/internal/controller/dnszone_helpers.go
@@ -13,7 +13,15 @@ func normalizeStringSlice(in []string) []string {
 	if len(in) == 0 {
 		return nil
 	}
-	out := append([]string(nil), in...)
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
 	sort.Strings(out)
 	return out
 }

--- a/internal/controller/dnszone_helpers_test.go
+++ b/internal/controller/dnszone_helpers_test.go
@@ -28,6 +28,14 @@ func TestNormalizeStringSlice(t *testing.T) {
 	if reflect.DeepEqual(in, want) {
 		t.Fatalf("expected input slice to remain unsorted")
 	}
+
+	// Duplicates are removed: a class listing each nameserver twice must not
+	// produce a doubled NS RRset (PowerDNS rejects duplicate records, 422).
+	dupIn := []string{"ns2", "ns1", "ns2", "ns1", "ns1"}
+	dupWant := []string{"ns1", "ns2"}
+	if dupGot := normalizeStringSlice(dupIn); !reflect.DeepEqual(dupGot, dupWant) {
+		t.Fatalf("expected dedup: got=%v want=%v", dupGot, dupWant)
+	}
 }
 
 func TestNormalizeDomainNameservers(t *testing.T) {

--- a/internal/pdns/client.go
+++ b/internal/pdns/client.go
@@ -80,6 +80,7 @@ type createZoneRequest struct {
 func (c *Client) CreateZone(ctx context.Context, zone string, nameservers []string) error {
 	// PDNS expects absolute nameserver hostnames (trailing dot)
 	nsAbs := make([]string, 0, len(nameservers))
+	seen := make(map[string]struct{}, len(nameservers))
 	for _, ns := range nameservers {
 		if ns == "" {
 			continue
@@ -87,6 +88,10 @@ func (c *Client) CreateZone(ctx context.Context, zone string, nameservers []stri
 		if ns[len(ns)-1] != '.' {
 			ns += "."
 		}
+		if _, ok := seen[ns]; ok {
+			continue
+		}
+		seen[ns] = struct{}{}
 		nsAbs = append(nsAbs, ns)
 	}
 	payload := createZoneRequest{
@@ -516,10 +521,15 @@ func buildRRSets(zone string, rs dnsv1alpha1.DNSRecordSet) []rrset {
 			}
 			v := strings.TrimSpace(rec.NS.Content)
 			if v != "" {
-				r.Records = append(r.Records, rrsetRecord{
-					Content:  qualifyIfNeeded(v),
-					Disabled: false,
-				})
+				// Dedupe by qualified content: PowerDNS rejects an RRset with
+				// duplicate records (422), and duplicates reach here when the
+				// nameserver source lists an NS twice, including trailing-dot
+				// variants (ns1.example.net vs ns1.example.net.) that collapse
+				// to identical content only after qualifyIfNeeded.
+				content := qualifyIfNeeded(v)
+				if !recordContentExists(r.Records, content) {
+					r.Records = append(r.Records, rrsetRecord{Content: content, Disabled: false})
+				}
 			}
 
 		case dnsv1alpha1.RRTypeSOA:
@@ -728,6 +738,15 @@ func makeSimpleRRSet(name, typ string, ttl int, values []string) rrset {
 		ChangeType: "REPLACE",
 		Records:    recs,
 	}
+}
+
+func recordContentExists(recs []rrsetRecord, content string) bool {
+	for _, r := range recs {
+		if r.Content == content {
+			return true
+		}
+	}
+	return false
 }
 
 func qualifyOwner(owner, zone string) string {

--- a/internal/pdns/pdns_test.go
+++ b/internal/pdns/pdns_test.go
@@ -677,6 +677,35 @@ func TestApplyRecordSetAuthoritative_PathAndHeaders(t *testing.T) {
 	}
 }
 
+// Duplicate NS content (including trailing-dot variants) must collapse to a
+// single record; PowerDNS rejects an RRset with duplicate records (422).
+func TestBuildRRSets_NSDedup(t *testing.T) {
+	t.Parallel()
+	rs := dnsv1alpha1.DNSRecordSet{
+		Spec: dnsv1alpha1.DNSRecordSetSpec{
+			RecordType: dnsv1alpha1.RRTypeNS,
+			Records: []dnsv1alpha1.RecordEntry{
+				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns1.example.net."}},
+				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns1.example.net"}}, // trailing-dot variant
+				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns1.example.net."}}, // exact dup
+				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns2.example.net."}},
+			},
+		},
+	}
+	rr := buildRRSets("example.com", rs)
+	if len(rr) != 1 {
+		t.Fatalf("expected 1 rrset, got %#v", rr)
+	}
+	got := []string{}
+	for _, rec := range rr[0].Records {
+		got = append(got, rec.Content)
+	}
+	want := []string{"ns1.example.net.", "ns2.example.net."}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NS dedup: got %#v want %#v", got, want)
+	}
+}
+
 // sanity: makeSimpleRRSet keeps values verbatim (used after we normalize)
 func TestMakeSimpleRRSet(t *testing.T) {
 	t.Parallel()

--- a/internal/pdns/pdns_test.go
+++ b/internal/pdns/pdns_test.go
@@ -686,7 +686,7 @@ func TestBuildRRSets_NSDedup(t *testing.T) {
 			RecordType: dnsv1alpha1.RRTypeNS,
 			Records: []dnsv1alpha1.RecordEntry{
 				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns1.example.net."}},
-				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns1.example.net"}}, // trailing-dot variant
+				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns1.example.net"}},  // trailing-dot variant
 				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns1.example.net."}}, // exact dup
 				{Name: "@", NS: &dnsv1alpha1.NSRecordSpec{Content: "ns2.example.net."}},
 			},


### PR DESCRIPTION
## What

Newly-created DNSZones in prod failed to program: PowerDNS rejected the default NS RRset PATCH with `422 "duplicate record with content"`, so zones never reached `Accepted`/`Programmed`. This blocked every new zone and the infra Integration Chainsaw `dns-setup` test (#51, Mode 1 — the fleet-wide blocker).

## Root cause

The `DNSZoneClass` `NameServerPolicy.Static.Servers` list carried each nameserver more than once, and **nothing on the path deduped it**:

- `normalizeStringSlice` sorted but kept duplicates → doubled `Status.Nameservers` (downstream, then mirrored upstream).
- `ensureNSRecordSet` emitted one NS `RecordEntry` per (duplicate) entry.
- `buildRRSets` NS case appended one record per entry → the PATCH carried duplicate NS records → 422.

Trailing-dot variants (`ns1.datumdns.net` vs `ns1.datumdns.net.`) made it worse: they only collapse to identical content *after* `qualifyIfNeeded`, so a raw-string dedupe alone isn't sufficient.

## Fix (three NS-scoped dedupe points)

- **`normalizeStringSlice`** — drop duplicate entries. Cleans both downstream and upstream `Status.Nameservers` at the source (also makes the CR status correct).
- **`CreateZone`** — dedupe the apex nameserver list sent at zone creation.
- **`buildRRSets` NS case** — dedupe by **qualified** content, collapsing exact dups *and* trailing-dot variants right before the PATCH is built. This is the guaranteed 422 fix regardless of what the source list contains.

## Scope

Mode 1 (duplicate NS) only, per triage. The other two modes from #51 are tracked as sub-issues and a separate PR:
- Mode 2 — CNAME multi-valued/duplicate content (single-value enforcement + dedupe).
- Mode 3 — ALIAS written where another RRset already exists (conflict handling).

Complementary: #52 surfaces the specific pdns 422 detail into the DNSRecordSet status.

## Test

- `internal/pdns` — `TestBuildRRSets_NSDedup`: exact dup + trailing-dot variant collapse to one record.
- `internal/controller` — `TestNormalizeStringSlice`: duplicates removed.
- `go build ./...` clean; affected unit tests pass. (The pdns package's Docker/testcontainers integration test is unrelated and not run here.)

Refs #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)
