### PR TITLE
fix: enforce single-value CNAME/ALIAS and flag coexistence conflicts

### DIFF
--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -13,4 +13,5 @@ const (
 	ReasonDNSZoneInUse        = "DNSZoneInUse"
 	ReasonNotOwner            = "NotOwner"
 	ReasonPDNSError           = "PDNSError"
+	ReasonConflict            = "Conflict"
 )

--- a/internal/controller/dnsrecordset_powerdns_controller.go
+++ b/internal/controller/dnsrecordset_powerdns_controller.go
@@ -199,7 +199,14 @@ func (r *DNSRecordSetPowerDNSReconciler) setRecordProgrammedCondition(
 		newCond.Message = "Another DNSRecordSet owns this record"
 	case pdnsErr != nil:
 		newCond.Status = metav1.ConditionFalse
-		newCond.Reason = ReasonPDNSError
+		if pdnsclient.IsConflict(pdnsErr) {
+			// CNAME/ALIAS coexistence conflict: well-formed record, but it
+			// cannot share this name with existing data. Distinct reason so it
+			// is greppable and not mistaken for a transient provider error.
+			newCond.Reason = ReasonConflict
+		} else {
+			newCond.Reason = ReasonPDNSError
+		}
 		newCond.Message = pdnsclient.FriendlyMessage(pdnsErr)
 	default:
 		newCond.Status = metav1.ConditionTrue

--- a/internal/pdns/client.go
+++ b/internal/pdns/client.go
@@ -456,8 +456,10 @@ func buildRRSets(zone string, rs dnsv1alpha1.DNSRecordSet) []rrset {
 			}
 			target := strings.TrimSpace(rec.CNAME.Content)
 			target = qualifyIfNeeded(target)
-			if target != "" {
-				// TODO: Technically this is a violation of the RFC, but we'll allow it for now.
+			if target != "" && len(r.Records) == 0 {
+				// CNAME is single-valued (RFC 1034): keep exactly one record.
+				// First non-empty entry wins; extras/duplicates are dropped, as
+				// PowerDNS rejects a multi-valued or duplicate CNAME RRset (422).
 				r.Records = append(r.Records, rrsetRecord{Content: target, Disabled: false})
 			}
 
@@ -604,7 +606,9 @@ func buildRRSets(zone string, rs dnsv1alpha1.DNSRecordSet) []rrset {
 			}
 			target := strings.TrimSpace(rec.ALIAS.Content)
 			target = qualifyIfNeeded(target)
-			if target != "" {
+			if target != "" && len(r.Records) == 0 {
+				// ALIAS is single-valued at an owner name: keep one record.
+				// First non-empty entry wins; extras/duplicates are dropped.
 				r.Records = append(r.Records, rrsetRecord{Content: target, Disabled: false})
 			}
 

--- a/internal/pdns/errors.go
+++ b/internal/pdns/errors.go
@@ -57,3 +57,22 @@ func FriendlyMessage(err error) string {
 		return "Failed to apply DNS record. It will be retried automatically."
 	}
 }
+
+// IsConflict reports whether err is a PowerDNS rejection caused by a record
+// coexistence conflict — a CNAME or ALIAS RRset that cannot share an owner name
+// with a pre-existing RRset. This is distinct from a malformed payload: the
+// record is well-formed but conflicts with existing data at the same name.
+func IsConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *pdnsAPIError
+	if !errors.As(err, &apiErr) || apiErr.Status != 422 {
+		return false
+	}
+	var body pdnsErrorBody
+	if apiErr.Body != "" {
+		_ = json.Unmarshal([]byte(apiErr.Body), &body)
+	}
+	return strings.Contains(body.Error, "Conflicts with pre-existing RRset")
+}

--- a/internal/pdns/errors_test.go
+++ b/internal/pdns/errors_test.go
@@ -87,3 +87,40 @@ func TestFriendlyMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestIsConflict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"non-pdns error", errors.New("boom"), false},
+		{
+			"ALIAS coexistence conflict",
+			&pdnsAPIError{Status: 422, Body: `{"error": "RRset www.ab.dk. IN ALIAS: Conflicts with pre-existing RRset"}`},
+			true,
+		},
+		{
+			"non-conflict 422 (duplicate record)",
+			&pdnsAPIError{Status: 422, Body: `{"error": "RRset x. IN NS: duplicate record with content \"ns1.\""}`},
+			false,
+		},
+		{
+			"non-422 status",
+			&pdnsAPIError{Status: 500, Body: `{"error": "Conflicts with pre-existing RRset"}`},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsConflict(tt.err); got != tt.want {
+				t.Errorf("IsConflict() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pdns/pdns_test.go
+++ b/internal/pdns/pdns_test.go
@@ -677,6 +677,44 @@ func TestApplyRecordSetAuthoritative_PathAndHeaders(t *testing.T) {
 	}
 }
 
+// CNAME and ALIAS are single-valued at an owner name: multiple/duplicate
+// entries must collapse to exactly one record (PowerDNS rejects otherwise, 422).
+func TestBuildRRSets_CNAMEAliasSingleValue(t *testing.T) {
+	t.Parallel()
+
+	rsCNAME := dnsv1alpha1.DNSRecordSet{
+		Spec: dnsv1alpha1.DNSRecordSetSpec{
+			RecordType: dnsv1alpha1.RRTypeCNAME,
+			Records: []dnsv1alpha1.RecordEntry{
+				{Name: "www", CNAME: &dnsv1alpha1.CNAMERecordSpec{Content: "target.example.net."}},
+				{Name: "www", CNAME: &dnsv1alpha1.CNAMERecordSpec{Content: "target.example.net."}},
+				{Name: "www", CNAME: &dnsv1alpha1.CNAMERecordSpec{Content: "other.example.net."}},
+			},
+		},
+	}
+	rr := buildRRSets("example.com", rsCNAME)
+	if len(rr) != 1 || len(rr[0].Records) != 1 {
+		t.Fatalf("CNAME single-value: expected 1 rrset/1 record, got %#v", rr)
+	}
+	if rr[0].Records[0].Content != "target.example.net." {
+		t.Fatalf("CNAME single-value: first-wins expected target.example.net., got %q", rr[0].Records[0].Content)
+	}
+
+	rsALIAS := dnsv1alpha1.DNSRecordSet{
+		Spec: dnsv1alpha1.DNSRecordSetSpec{
+			RecordType: dnsv1alpha1.RRTypeALIAS,
+			Records: []dnsv1alpha1.RecordEntry{
+				{Name: "@", ALIAS: &dnsv1alpha1.ALIASRecordSpec{Content: "lb.example.net."}},
+				{Name: "@", ALIAS: &dnsv1alpha1.ALIASRecordSpec{Content: "lb.example.net."}},
+			},
+		},
+	}
+	rr = buildRRSets("example.com", rsALIAS)
+	if len(rr) != 1 || len(rr[0].Records) != 1 {
+		t.Fatalf("ALIAS single-value: expected 1 rrset/1 record, got %#v", rr)
+	}
+}
+
 // sanity: makeSimpleRRSet keeps values verbatim (used after we normalize)
 func TestMakeSimpleRRSet(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What

Addresses the two non-blocker 422 modes from #51:

- **Mode 2 (#55)** — CNAME/ALIAS multi-valued or duplicate content.
- **Mode 3 (#56)** — ALIAS written where a conflicting RRset already exists.

Follows #54 (duplicate-NS, Mode 1) and complements #52 (surface pdns detail in status).

## Mode 2 — single-value CNAME/ALIAS

`buildRRSets` appended one record per entry for CNAME and ALIAS with no constraint (the CNAME case even had `// TODO: ...violation of the RFC...we'll allow it`). A `DNSRecordSet` (or discovery aggregating the same answer from multiple resolvers) with repeated/multiple content produced a multi-valued RRset that PowerDNS rejects:

```
RRset www.ibm.com. IN CNAME: only one such record allowed
RRset www.ibm.com. IN CNAME: duplicate record with content "...edgekey.net"
```

Both cases now keep exactly one record (first non-empty entry wins), so a malformed input can no longer produce an invalid payload.

## Mode 3 — flag ALIAS coexistence conflicts distinctly

An ALIAS at a name that already holds another RRset returns `422 "Conflicts with pre-existing RRset"`. That's a well-formed record that *cannot coexist* — not a transient provider error. New `pdns.IsConflict()` classifies it, and the reconciler sets a distinct `Programmed=False` reason **`Conflict`** (vs generic `PDNSError`), so it's greppable in the DNSRecordSet status and clearly actionable.

### Deferred (intentionally)

Pre-flight conflict *prevention* — checking existing RRsets and refusing/clearing before the PATCH — is not included. Doing it correctly needs the real PowerDNS coexistence rules (e.g. ALIAS at apex legitimately coexists with SOA/NS, so a naive "any other type = conflict" check would wrongly block valid apex ALIAS) plus integration testing against pdns. Left for a follow-up; #56 tracks it. The current PR makes the conflict safe and legible; the 30s-capped reconcile backoff still self-heals once the conflicting record is removed.

## Test

- `internal/pdns` — `TestBuildRRSets_CNAMEAliasSingleValue` (multi/dup collapse to one, first-wins), `TestIsConflict` (conflict vs non-conflict 422 vs non-422).
- `go build ./...` clean; `internal/pdns` + `internal/controller` unit tests pass. (Docker/testcontainers integration test unrelated, not run.)

Closes #55
Closes #56
Refs #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)
