### PR TITLE
feat: End-to-end DNS federation e2e environment (upstream→control→edge) in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,15 @@ jobs:
   e2e:
     name: Run Chainsaw E2E Tests
     runs-on: ubuntu-latest
+    # Three test-infra kind clusters (upstream + control + edge), each with
+    # Flux/cert-manager/Kyverno/Envoy Gateway, plus RustFS and a Lightningstream
+    # sync interval the federation/full-chain suites poll for - give it headroom.
+    timeout-minutes: 60
+    env:
+      # The Taskfile pulls in the shared datum-cloud/test-infra Taskfile as a
+      # remote include; go-task gates that behind this experiment flag, and
+      # `--yes` (below) auto-accepts the download in this non-interactive run.
+      TASK_X_REMOTE_TASKFILES: "1"
     steps:
       - name: Clone the code
         uses: actions/checkout@v4
@@ -26,34 +35,61 @@ jobs:
         with:
           install_only: true
 
-      - name: Bootstrap e2e environment
-        run: make bootstrap-e2e
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Wait for controllers to be ready
+      - name: Install Chainsaw
+        # env:chainsaw invokes `chainsaw` from PATH; `make chainsaw` installs
+        # the pinned version into ./bin, which we add to PATH here.
         run: |
-          kubectl --context kind-dns-upstream -n dns-replicator-system rollout status deployment/dns-operator-controller-manager --timeout=120s
-          kubectl --context kind-dns-downstream -n dns-agent-system rollout status statefulset/pdns-auth --timeout=120s
+          make chainsaw
+          echo "$GITHUB_WORKSPACE/bin" >> "$GITHUB_PATH"
 
-      - name: Prepare kubeconfigs for Chainsaw
-        run: make chainsaw-prepare-kubeconfigs
+      - name: Bring up the full DNS environment
+        # Creates the upstream (replicator) + control (downstream agent +
+        # PowerDNS + Lightningstream + RustFS) + edge clusters and wires the
+        # whole production chain together. No sample data (env:stack-up, not
+        # env:up) so the suites own all zones on the shared control PowerDNS.
+        run: task --yes env:stack-up
 
       - name: Run Chainsaw tests
-        run: make chainsaw-test
+        # Runs every suite under test/e2e against the environment: the
+        # upstream->control replicator suites (alias, display-annotations,
+        # zones-and-records), the control->edge Lightningstream suite
+        # (federation), and the end-to-end upstream->edge suite (full-chain).
+        run: task --yes env:chainsaw
 
       - name: Collect diagnostic logs
         if: failure()
+        env:
+          KUBECONFIG: dev/kubeconfig
         run: |
-          echo "=== Upstream controller logs ==="
+          echo "=== [upstream] replicator logs ==="
           kubectl --context kind-dns-upstream -n dns-replicator-system logs deployment/dns-operator-controller-manager --tail=200 || true
           echo ""
-          echo "=== Upstream controller describe ==="
-          kubectl --context kind-dns-upstream -n dns-replicator-system describe deployment/dns-operator-controller-manager || true
+          echo "=== [upstream] DNSZones / DNSRecordSets ==="
+          kubectl --context kind-dns-upstream get dnszones,dnsrecordsets -A || true
           echo ""
-          echo "=== Downstream agent logs ==="
-          kubectl --context kind-dns-downstream -n dns-agent-system logs statefulset/pdns-auth --tail=100 || true
-          echo ""
-          echo "=== DNSZones in upstream ==="
-          kubectl --context kind-dns-upstream get dnszones -A || true
-          echo ""
-          echo "=== DNSZones in downstream ==="
-          kubectl --context kind-dns-downstream get dnszones -A || true
+          for ctx in kind-dns-control kind-dns-edge; do
+            echo "=== [$ctx] pods (all namespaces) ==="
+            kubectl --context "$ctx" get pods -A || true
+            echo ""
+            echo "=== [$ctx] dns-operator agent logs (manager) ==="
+            kubectl --context "$ctx" -n dns-agent-system logs statefulset/pdns-auth -c manager --tail=200 || true
+            echo ""
+            echo "=== [$ctx] lightningstream logs ==="
+            kubectl --context "$ctx" -n dns-agent-system logs statefulset/pdns-auth -c lightningstream --tail=200 || true
+            echo ""
+            echo "=== [$ctx] DNSZones / DNSRecordSets ==="
+            kubectl --context "$ctx" get dnszones,dnsrecordsets -A || true
+            echo ""
+          done
+          echo "=== RustFS logs (control) ==="
+          kubectl --context kind-dns-control -n rustfs-system logs -l app.kubernetes.io/instance=rustfs --tail=100 || true
+
+      - name: Tear down the environment
+        if: always()
+        run: task --yes env:down || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,18 @@ jobs:
       - name: Clone the code
         uses: actions/checkout@v4
 
+      - name: Free up disk space
+        # Three test-infra kind clusters (Flux/cert-manager/Kyverno/Envoy each)
+        # plus PowerDNS/RustFS/Lightningstream/operator images overflow the
+        # runner's ~14GB OS disk, which thrashes `kind load` (observed ~14min)
+        # and destabilizes the API servers. Reclaim ~20GB of preinstalled
+        # toolchains we don't use (keep /opt/hostedtoolcache - Go/Task live there).
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+            /usr/local/share/boost /opt/hostedtoolcache/CodeQL /usr/local/share/powershell || true
+          sudo docker image prune --all --force || true
+          df -h /
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ config/**/charts
 .test-infra/
 .task/
 
+# Per-cluster kubeconfigs generated for the e2e Chainsaw suites
+# (make chainsaw-prepare-kubeconfigs / task env:chainsaw-prepare-kubeconfigs)
+test/e2e/kubeconfig-*
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ dev/
 .go-version
 config/**/charts
 
+# test-infra repo clone, managed by Taskfile.yaml (see includes.test-infra)
+.test-infra/
+.task/
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ kubectl apply -k config/overlays/replicator
 ```
 3. Create `DNSZoneClass` (cluster-scoped), `DNSZone` and `DNSRecordSet` on the upstream cluster. The replicator will mirror them into the downstream cluster and update upstream `status` conditions.
 
+### Quickstart: Local DNS platform environment (control + edge federation)
+
+Brings up two [kind](https://kind.sigs.k8s.io/) clusters on the shared [`datum-cloud/test-infra`](https://github.com/datum-cloud/test-infra) tooling (same pattern as `milo-os/activity`) to exercise the full production topology end-to-end: dns-operator + PowerDNS on a "control" cluster, PowerDNS-only on an "edge" cluster, replicating zone data between them via PowerDNS Lightningstream over a shared [RustFS](https://rustfs.com) (S3-compatible) bucket — the same mechanism production uses to replicate zone data to edge PoPs over GCS.
+
+```bash
+export TASK_X_REMOTE_TASKFILES=1
+task env:up          # control cluster (dns-operator + PowerDNS + RustFS) + edge cluster (PowerDNS)
+task env:dns-check   # confirm the sample record replicated from control to edge
+task env:down        # tear down both clusters
+```
+
+See `Taskfile.yaml` for the individual `env:control-up` / `env:edge-up` steps, and `config/overlays/agent-powerdns-federated` / `config/dependencies/rustfs` for the underlying manifests.
+
 ### Conditions
 - `Accepted`: resource is valid and has required dependencies (e.g., `DNSRecordSet` sees its `DNSZone`)
 - `Programmed`: desired state is realized (shadow exists downstream; for downstream agent, recordsets applied to backend)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,256 @@
+# Local DNS platform environment, built on the shared datum-cloud/test-infra
+# tooling (same pattern milo-os/activity uses: a pinned remote Taskfile
+# include). Requires:
+#   export TASK_X_REMOTE_TASKFILES=1
+#
+# `task env:up` brings up two kind clusters - "control" (dns-operator +
+# PowerDNS + RustFS) and "edge" (PowerDNS only) - and verifies that zone data
+# written on the control cluster replicates to the edge cluster via PowerDNS
+# Lightningstream over a shared RustFS (S3-compatible) bucket, the same way
+# production replicates zone data to edge PoPs over GCS.
+version: '3'
+
+vars:
+  # Bump to the merged tag once datum-cloud/test-infra#35 lands (it removes
+  # the hardcoded NodePorts that block running two clusters concurrently).
+  TEST_INFRA_REPO_REF: 'fix/remove-hardcoded-nodeports'
+  CONTROL_CLUSTER_NAME: 'dns-control'
+  EDGE_CLUSTER_NAME: 'dns-edge'
+  IMG: 'ghcr.io/datum-cloud/dns-operator:latest'
+  RUSTFS_BUCKET: 'lightningstream'
+  RUSTFS_NODEPORT_FILE: 'dev/rustfs.nodeport'
+  # Dedicated kubeconfig for this environment (not the user's default
+  # ~/.kube/config). go-task's `env:` blocks are implemented as process-wide
+  # os.Setenv calls that leak between sibling task/cmd invocations (a known
+  # go-task quirk, not scoped per-task as the docs imply) - the included
+  # test-infra Taskfile sets KUBECONFIG to its own `.test-infra/kubeconfig`
+  # this way, and that value silently leaks into every cmd we run for the
+  # rest of the process, clobbering the default kubeconfig assumption. Every
+  # kubectl/kind/make invocation below explicitly sets KUBECONFIG to this
+  # fixed path so behavior doesn't depend on call order or that leak.
+  ENV_KUBECONFIG: 'dev/kubeconfig'
+
+includes:
+  test-infra:
+    taskfile: https://raw.githubusercontent.com/datum-cloud/test-infra/{{.TEST_INFRA_REPO_REF}}/Taskfile.yml
+    vars:
+      REPO_REF: "{{.TEST_INFRA_REPO_REF}}"
+
+tasks:
+  default:
+    desc: "Show available commands"
+    silent: true
+    cmds:
+      - echo "DNS platform local environment (control + edge PowerDNS federation):"
+      - echo "  task env:up          Bring up control + edge clusters, deploy a sample zone"
+      - echo "  task env:down        Tear down both clusters"
+      - echo "  task env:dns-check   Query both clusters' PowerDNS for the sample record"
+      - echo ""
+      - echo "Individual pieces:"
+      - echo "  task env:control-up  Control cluster only (dns-operator + PowerDNS + RustFS)"
+      - echo "  task env:edge-up     Edge cluster only (PowerDNS, replicates from control)"
+      - echo ""
+      - echo "Underlying test-infra tasks are available as test-infra:<name>, e.g.:"
+      - echo "  task test-infra:kubectl -- get pods --all-namespaces"
+
+  env:rustfs-up:
+    desc: "Deploy RustFS (S3-compatible object store) into the control cluster via Flux"
+    silent: true
+    cmds:
+      - echo "➡️  Installing RustFS into kind-{{.CONTROL_CLUSTER_NAME}}..."
+      - KUBECONFIG={{.ENV_KUBECONFIG}} kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} apply -k config/dependencies/rustfs
+      - KUBECONFIG={{.ENV_KUBECONFIG}} kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} -n rustfs-system wait helmrelease/rustfs --for=condition=Ready --timeout=300s
+      - |
+        set -euo pipefail
+        export KUBECONFIG={{.ENV_KUBECONFIG}}
+        mkdir -p dev
+        SVC=$(kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} get svc -n rustfs-system -l app.kubernetes.io/instance=rustfs -o jsonpath='{.items[0].metadata.name}')
+        kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} -n rustfs-system wait --for=jsonpath='{.spec.ports[0].nodePort}' svc/$SVC --timeout=60s
+        PORT=$(kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} get svc -n rustfs-system $SVC -o jsonpath='{.spec.ports[0].nodePort}')
+        echo "$PORT" > {{.RUSTFS_NODEPORT_FILE}}
+        echo "✅ RustFS ready: svc/$SVC, NodePort=$PORT (recorded to {{.RUSTFS_NODEPORT_FILE}})"
+      # RustFS (like any S3-compatible store) does not auto-create buckets,
+      # and the pinned chart version predates its `setup.buckets` hook (see
+      # config/dependencies/rustfs/helmrelease.yaml) - so create the bucket
+      # Lightningstream syncs snapshots through ourselves, via a one-off pod.
+      # Without this, lightningstream just polls forever logging
+      # "list snapshots: Volume not found" and never actually syncs.
+      - |
+        set -euo pipefail
+        export KUBECONFIG={{.ENV_KUBECONFIG}}
+        kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} -n rustfs-system delete pod rustfs-mb --ignore-not-found
+        kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} -n rustfs-system run rustfs-mb \
+          --image=amazon/aws-cli:2.17.62 --restart=Never \
+          --env=AWS_ACCESS_KEY_ID=dns-federation --env=AWS_SECRET_ACCESS_KEY=dns-federation-secret \
+          --command -- \
+          sh -c "aws --endpoint-url http://rustfs.rustfs-system.svc.cluster.local:9000 s3 mb s3://{{.RUSTFS_BUCKET}} --region us-east-1 || true"
+        kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} -n rustfs-system wait --for=jsonpath='{.status.phase}'=Succeeded pod/rustfs-mb --timeout=60s
+        echo "✅ RustFS bucket '{{.RUSTFS_BUCKET}}' ready"
+
+  # internal: writes/updates the s3-credentials Secret dns-operator's agent
+  # (see config/agent/manager.yaml) reads its Lightningstream S3 config from.
+  env:s3-secret:
+    internal: true
+    silent: true
+    cmds:
+      - |
+        set -euo pipefail
+        export KUBECONFIG={{.ENV_KUBECONFIG}}
+        kubectl --context {{.CONTEXT}} create namespace dns-agent-system --dry-run=client -o yaml | kubectl --context {{.CONTEXT}} apply -f -
+        kubectl --context {{.CONTEXT}} -n dns-agent-system create secret generic s3-credentials \
+          --from-literal=accesskey=dns-federation \
+          --from-literal=secretkey=dns-federation-secret \
+          --from-literal=endpoint_url={{.ENDPOINT_URL}} \
+          --from-literal=bucket={{.RUSTFS_BUCKET}} \
+          --from-literal=region=us-east-1 \
+          --from-literal=cluster_id={{.CLUSTER_ID}}- \
+          --dry-run=client -o yaml | kubectl --context {{.CONTEXT}} apply -f -
+        echo "✅ s3-credentials set in {{.CONTEXT}}: endpoint_url={{.ENDPOINT_URL}}"
+        # The pdns-auth StatefulSet (see config/agent/manager.yaml) is applied
+        # by kustomize-apply BEFORE this secret exists, so its lightningstream
+        # container's secretKeyRef env vars (optional: true) start out empty.
+        # Kubernetes does not live-update already-injected env vars when a
+        # Secret is created/changed, so restart the pod to pick them up.
+        kubectl --context {{.CONTEXT}} -n dns-agent-system rollout restart statefulset/pdns-auth
+        kubectl --context {{.CONTEXT}} -n dns-agent-system rollout status statefulset/pdns-auth --timeout=120s
+
+  # internal: brings up a test-infra-managed kind cluster (kind cluster +
+  # Flux + cert-manager + Kyverno + Envoy Gateway) for CLUSTER_NAME.
+  #
+  # NOTE: this deliberately calls the individual test-infra sub-tasks
+  # (ensure-repo/ensure-tools/create-kind/install-components) instead of the
+  # composite `test-infra:cluster-up`/`up` task. As of test-infra's
+  # fix/remove-hardcoded-nodeports branch (and go-task 3.49/3.50),
+  # `cluster-up`'s trailing informational `echo "... # ..."` lines panic
+  # go-task's command parser ("reached EOF without closing quote") because
+  # go-task strips ` #...` as a shell comment even inside double quotes on
+  # single-line (non `|` block) cmd entries - a go-task parsing quirk, not
+  # a shell issue. Calling the sub-tasks directly gets the same cluster
+  # setup while skipping the broken trailing echoes. If that upstream
+  # Taskfile is fixed (or go-task fixes the quoting bug), this can go back
+  # to a single `task: test-infra:cluster-up` call.
+  env:test-infra-cluster-up:
+    internal: true
+    cmds:
+      - task: test-infra:ensure-repo
+        vars:
+          CLUSTER_NAME: "{{.CLUSTER_NAME}}"
+      - task: test-infra:ensure-tools
+        vars:
+          CLUSTER_NAME: "{{.CLUSTER_NAME}}"
+      - task: test-infra:create-kind
+        vars:
+          CLUSTER_NAME: "{{.CLUSTER_NAME}}"
+      - task: test-infra:install-components
+        vars:
+          CLUSTER_NAME: "{{.CLUSTER_NAME}}"
+      # test-infra's create-kind writes the cluster's kubeconfig to its own
+      # KUBECONFIG_FILE (e.g. .test-infra/kubeconfig when run from an
+      # external repo like this one) via `kind create cluster --kubeconfig
+      # <file>`, which does NOT merge a kind-<name> context into the
+      # default kubeconfig. Every other task in this Taskfile (and `make`
+      # targets it shells out to) assumes the standard `kubectl --context
+      # kind-<name>` convention, so re-export/merge it into the default
+      # kubeconfig here - into our own dedicated ENV_KUBECONFIG file (not the
+      # default ~/.kube/config, which is subject to the same leaked-env risk
+      # via kind's own default KUBECONFIG resolution). Every subsequent cmd
+      # in this Taskfile explicitly sets KUBECONFIG to ENV_KUBECONFIG too.
+      - kind export kubeconfig --name {{.CLUSTER_NAME}} --kubeconfig {{.ENV_KUBECONFIG}}
+
+  env:control-up:
+    desc: "Create the control kind cluster and deploy dns-operator + PowerDNS + RustFS"
+    cmds:
+      - task: env:test-infra-cluster-up
+        vars:
+          CLUSTER_NAME: "{{.CONTROL_CLUSTER_NAME}}"
+      - task: env:rustfs-up
+      - CLUSTER={{.CONTROL_CLUSTER_NAME}} IMG={{.IMG}} make kind-load-image
+      - KUBECONFIG={{.ENV_KUBECONFIG}} CONTEXT=kind-{{.CONTROL_CLUSTER_NAME}} make install-dns-operator-crds
+      - KUBECONFIG={{.ENV_KUBECONFIG}} CONTEXT=kind-{{.CONTROL_CLUSTER_NAME}} KUSTOMIZE_DIR=config/overlays/agent-powerdns-federated make kustomize-apply
+      - task: env:s3-secret
+        vars:
+          CONTEXT: "kind-{{.CONTROL_CLUSTER_NAME}}"
+          CLUSTER_ID: "{{.CONTROL_CLUSTER_NAME}}"
+          ENDPOINT_URL:
+            sh: |
+              export KUBECONFIG={{.ENV_KUBECONFIG}}
+              SVC=$(kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} get svc -n rustfs-system -l app.kubernetes.io/instance=rustfs -o jsonpath='{.items[0].metadata.name}')
+              echo "http://$SVC.rustfs-system.svc.cluster.local:9000"
+      - echo "✅ control cluster (kind-{{.CONTROL_CLUSTER_NAME}}) ready"
+
+  env:edge-up:
+    desc: "Create the edge kind cluster and deploy PowerDNS pointed at the control cluster's RustFS"
+    cmds:
+      - |
+        if [ ! -f {{.RUSTFS_NODEPORT_FILE}} ]; then
+          echo "❌ {{.RUSTFS_NODEPORT_FILE}} not found - run 'task env:control-up' first"
+          exit 1
+        fi
+      - task: env:test-infra-cluster-up
+        vars:
+          CLUSTER_NAME: "{{.EDGE_CLUSTER_NAME}}"
+      - CLUSTER={{.EDGE_CLUSTER_NAME}} IMG={{.IMG}} make kind-load-image
+      - KUBECONFIG={{.ENV_KUBECONFIG}} CONTEXT=kind-{{.EDGE_CLUSTER_NAME}} make install-dns-operator-crds
+      - KUBECONFIG={{.ENV_KUBECONFIG}} CONTEXT=kind-{{.EDGE_CLUSTER_NAME}} KUSTOMIZE_DIR=config/overlays/agent-powerdns-federated make kustomize-apply
+      - task: env:s3-secret
+        vars:
+          CONTEXT: "kind-{{.EDGE_CLUSTER_NAME}}"
+          CLUSTER_ID: "{{.EDGE_CLUSTER_NAME}}"
+          ENDPOINT_URL:
+            sh: echo "http://{{.CONTROL_CLUSTER_NAME}}-control-plane:$(cat {{.RUSTFS_NODEPORT_FILE}})"
+      - echo "✅ edge cluster (kind-{{.EDGE_CLUSTER_NAME}}) ready"
+
+  env:up:
+    desc: "Bring up the full local DNS federation environment (control + edge clusters)"
+    cmds:
+      - task: env:control-up
+      - task: env:edge-up
+      - KUBECONFIG={{.ENV_KUBECONFIG}} kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} apply -f config/samples/federation/dnszone-example.yaml
+      - echo ""
+      - echo "🎉 Environment up. control=kind-{{.CONTROL_CLUSTER_NAME}} edge=kind-{{.EDGE_CLUSTER_NAME}}"
+      - echo "   Lightningstream syncs on an interval - give it a few seconds, then:"
+      - echo "   task env:dns-check"
+
+  env:dns-check:
+    desc: "Query both control and edge PowerDNS for the sample www.example.com record"
+    cmds:
+      - echo "🔎 control (kind-{{.CONTROL_CLUSTER_NAME}}):"
+      - KUBECONFIG={{.ENV_KUBECONFIG}} make dns-debug DNS_DEBUG_CONTEXT=kind-{{.CONTROL_CLUSTER_NAME}} DNS_DEBUG_ZONE=example.com DNS_DEBUG_HOST=www
+      - echo "🔎 edge (kind-{{.EDGE_CLUSTER_NAME}}) - should match control once Lightningstream syncs:"
+      - KUBECONFIG={{.ENV_KUBECONFIG}} make dns-debug DNS_DEBUG_CONTEXT=kind-{{.EDGE_CLUSTER_NAME}} DNS_DEBUG_ZONE=example.com DNS_DEBUG_HOST=www
+
+  env:chainsaw-prepare-kubeconfigs:
+    desc: "Export control/edge kind kubeconfigs into test/e2e/ for the federation Chainsaw test"
+    cmds:
+      - CLUSTER={{.CONTROL_CLUSTER_NAME}} OUT=test/e2e/kubeconfig-control make export-kind-kubeconfig-raw
+      - CLUSTER={{.EDGE_CLUSTER_NAME}} OUT=test/e2e/kubeconfig-edge make export-kind-kubeconfig-raw
+      - echo "✅ wrote test/e2e/kubeconfig-control and test/e2e/kubeconfig-edge"
+
+  env:chainsaw-federation:
+    desc: "Run the federation Chainsaw e2e test against the control/edge environment"
+    deps:
+      - env:chainsaw-prepare-kubeconfigs
+    cmds:
+      # Chainsaw needs *a* default KUBECONFIG to initialize its client even
+      # though this test only ever addresses the "control"/"edge" clusters
+      # by name (spec.clusters) - point it at the control kubeconfig we just
+      # exported.
+      - cd test/e2e && KUBECONFIG=kubeconfig-control chainsaw test federation/
+
+  env:down:
+    desc: "Tear down both clusters"
+    cmds:
+      # NOTE: calling the leaf `delete-kind` task directly (not the
+      # `cluster-down`/`down` wrapper) - go-task does not forward
+      # caller-supplied `vars:` through a wrapper task's own un-parameterized
+      # `task:` calls, so `test-infra:cluster-down vars: {CLUSTER_NAME: ...}`
+      # silently falls back to CLUSTER_NAME's taskfile-level default
+      # ("test-infra") instead of deleting the cluster we actually created.
+      # Same reasoning as env:test-infra-cluster-up above.
+      - task: test-infra:delete-kind
+        vars:
+          CLUSTER_NAME: "{{.CONTROL_CLUSTER_NAME}}"
+      - task: test-infra:delete-kind
+        vars:
+          CLUSTER_NAME: "{{.EDGE_CLUSTER_NAME}}"
+      - rm -f {{.RUSTFS_NODEPORT_FILE}} {{.ENV_KUBECONFIG}}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,11 +14,19 @@ vars:
   # Bump to the merged tag once datum-cloud/test-infra#35 lands (it removes
   # the hardcoded NodePorts that block running two clusters concurrently).
   TEST_INFRA_REPO_REF: 'fix/remove-hardcoded-nodeports'
+  # Upstream (control-plane) cluster runs the replicator; it pushes DNSZone/
+  # DNSRecordSet resources to the control cluster, which plays the "downstream"
+  # agent role for the replicator and the "control" (Lightningstream source)
+  # role for edge replication - one cluster, two roles, mirroring production.
+  UPSTREAM_CLUSTER_NAME: 'dns-upstream'
   CONTROL_CLUSTER_NAME: 'dns-control'
   EDGE_CLUSTER_NAME: 'dns-edge'
   IMG: 'ghcr.io/datum-cloud/dns-operator:latest'
   RUSTFS_BUCKET: 'lightningstream'
   RUSTFS_NODEPORT_FILE: 'dev/rustfs.nodeport'
+  # In-cluster-rewritten kubeconfig for the control cluster, mounted into the
+  # replicator (via a Secret) so it can reach control's API as its downstream.
+  CONTROL_INCLUSTER_KUBECONFIG: 'dev/control.incluster.kubeconfig'
   # Dedicated kubeconfig for this environment (not the user's default
   # ~/.kube/config). go-task's `env:` blocks are implemented as process-wide
   # os.Setenv calls that leak between sibling task/cmd invocations (a known
@@ -41,14 +49,17 @@ tasks:
     desc: "Show available commands"
     silent: true
     cmds:
-      - echo "DNS platform local environment (control + edge PowerDNS federation):"
-      - echo "  task env:up          Bring up control + edge clusters, deploy a sample zone"
-      - echo "  task env:down        Tear down both clusters"
-      - echo "  task env:dns-check   Query both clusters' PowerDNS for the sample record"
+      - echo "DNS platform local environment (upstream replicator + control + edge federation):"
+      - echo "  task env:up          Bring up upstream + control + edge clusters, deploy a sample zone"
+      - echo "  task env:stack-up    Bring up the full chain with no sample data (used by CI)"
+      - echo "  task env:chainsaw    Run the full Chainsaw e2e suite against the environment"
+      - echo "  task env:down        Tear down all clusters"
+      - echo "  task env:dns-check   Query control + edge PowerDNS for the sample record"
       - echo ""
       - echo "Individual pieces:"
       - echo "  task env:control-up  Control cluster only (dns-operator + PowerDNS + RustFS)"
       - echo "  task env:edge-up     Edge cluster only (PowerDNS, replicates from control)"
+      - echo "  task env:upstream-up Upstream cluster only (replicator, pushes to control)"
       - echo ""
       - echo "Underlying test-infra tasks are available as test-infra:<name>, e.g.:"
       - echo "  task test-infra:kubectl -- get pods --all-namespaces"
@@ -200,14 +211,57 @@ tasks:
             sh: echo "http://{{.CONTROL_CLUSTER_NAME}}-control-plane:$(cat {{.RUSTFS_NODEPORT_FILE}})"
       - echo "✅ edge cluster (kind-{{.EDGE_CLUSTER_NAME}}) ready"
 
-  env:up:
-    desc: "Bring up the full local DNS federation environment (control + edge clusters)"
+  env:upstream-up:
+    desc: "Create the upstream kind cluster and deploy the replicator pointed at the control (downstream agent) cluster"
     cmds:
+      - task: env:test-infra-cluster-up
+        vars:
+          CLUSTER_NAME: "{{.UPSTREAM_CLUSTER_NAME}}"
+      - CLUSTER={{.UPSTREAM_CLUSTER_NAME}} IMG={{.IMG}} make kind-load-image
+      - KUBECONFIG={{.ENV_KUBECONFIG}} CONTEXT=kind-{{.UPSTREAM_CLUSTER_NAME}} make install-dns-operator-crds
+      # The replicator's manager watches networking-services types (Domain,
+      # etc.) in addition to DNS resources; install those CRDs so its
+      # controllers start cleanly (mirrors `make bootstrap-upstream`).
+      - KUBECONFIG={{.ENV_KUBECONFIG}} CONTEXT=kind-{{.UPSTREAM_CLUSTER_NAME}} make install-networking-crds
+      # The replicator reaches the control cluster's API (its "downstream")
+      # through a kubeconfig Secret. Export control's kubeconfig rewritten to
+      # the control-plane container's in-network address (host:6443, TLS-skip)
+      # so it is reachable from the upstream cluster's pods over the shared
+      # kind docker network - the same cross-cluster addressing env:edge-up
+      # already uses for RustFS.
+      - CLUSTER={{.CONTROL_CLUSTER_NAME}} OUT={{.CONTROL_INCLUSTER_KUBECONFIG}} KIND_KUBECONFIG_INSECURE=true make export-kind-kubeconfig
+      - |
+        set -euo pipefail
+        export KUBECONFIG={{.ENV_KUBECONFIG}}
+        kubectl --context kind-{{.UPSTREAM_CLUSTER_NAME}} create namespace dns-replicator-system --dry-run=client -o yaml | kubectl --context kind-{{.UPSTREAM_CLUSTER_NAME}} apply -f -
+      - KUBECONFIG={{.ENV_KUBECONFIG}} CONTEXT=kind-{{.UPSTREAM_CLUSTER_NAME}} NAMESPACE=dns-replicator-system NAME=downstream-kubeconfig KEY=kubeconfig FILE={{.CONTROL_INCLUSTER_KUBECONFIG}} make secret-from-file
+      - KUBECONFIG={{.ENV_KUBECONFIG}} CONTEXT=kind-{{.UPSTREAM_CLUSTER_NAME}} KUSTOMIZE_DIR=config/overlays/replicator make kustomize-apply
+      - KUBECONFIG={{.ENV_KUBECONFIG}} kubectl --context kind-{{.UPSTREAM_CLUSTER_NAME}} -n dns-replicator-system rollout status deployment/dns-operator-controller-manager --timeout=180s
+      - echo "✅ upstream cluster (kind-{{.UPSTREAM_CLUSTER_NAME}}) ready"
+
+  env:stack-up:
+    desc: "Bring up all three clusters and the full DNS chain (no sample data) - used by CI"
+    cmds:
+      # Order matters: the replicator (upstream) needs the control cluster
+      # reachable, and edge needs control's RustFS NodePort, so control comes
+      # up first, then edge, then upstream.
       - task: env:control-up
       - task: env:edge-up
+      - task: env:upstream-up
+
+  env:up:
+    desc: "Bring up the full local DNS federation environment (upstream + control + edge) with sample data"
+    cmds:
+      - task: env:stack-up
+      # Dev convenience only: this applies the sample directly on the control
+      # cluster to smoke-test the control->edge Lightningstream path. CI uses
+      # env:stack-up instead and drives the full upstream->edge chain through
+      # the Chainsaw suites (see env:chainsaw), so it never applies this - the
+      # sample's example.com zone would otherwise collide with the
+      # zones-and-records suite on the shared control PowerDNS.
       - KUBECONFIG={{.ENV_KUBECONFIG}} kubectl --context kind-{{.CONTROL_CLUSTER_NAME}} apply -f config/samples/federation/dnszone-example.yaml
       - echo ""
-      - echo "🎉 Environment up. control=kind-{{.CONTROL_CLUSTER_NAME}} edge=kind-{{.EDGE_CLUSTER_NAME}}"
+      - echo "🎉 Environment up. upstream=kind-{{.UPSTREAM_CLUSTER_NAME}} control=kind-{{.CONTROL_CLUSTER_NAME}} edge=kind-{{.EDGE_CLUSTER_NAME}}"
       - echo "   Lightningstream syncs on an interval - give it a few seconds, then:"
       - echo "   task env:dns-check"
 
@@ -220,26 +274,35 @@ tasks:
       - KUBECONFIG={{.ENV_KUBECONFIG}} make dns-debug DNS_DEBUG_CONTEXT=kind-{{.EDGE_CLUSTER_NAME}} DNS_DEBUG_ZONE=example.com DNS_DEBUG_HOST=www
 
   env:chainsaw-prepare-kubeconfigs:
-    desc: "Export control/edge kind kubeconfigs into test/e2e/ for the federation Chainsaw test"
+    desc: "Export upstream/control/edge kind kubeconfigs into test/e2e/ for the Chainsaw suites"
     cmds:
+      - CLUSTER={{.UPSTREAM_CLUSTER_NAME}} OUT=test/e2e/kubeconfig-upstream make export-kind-kubeconfig-raw
+      # The control cluster is addressed as "downstream" by the replicator
+      # suites and as "control" by the federation/full-chain suites, so export
+      # its kubeconfig under both names.
+      - CLUSTER={{.CONTROL_CLUSTER_NAME}} OUT=test/e2e/kubeconfig-downstream make export-kind-kubeconfig-raw
       - CLUSTER={{.CONTROL_CLUSTER_NAME}} OUT=test/e2e/kubeconfig-control make export-kind-kubeconfig-raw
       - CLUSTER={{.EDGE_CLUSTER_NAME}} OUT=test/e2e/kubeconfig-edge make export-kind-kubeconfig-raw
-      - echo "✅ wrote test/e2e/kubeconfig-control and test/e2e/kubeconfig-edge"
+      - echo "✅ wrote test/e2e/kubeconfig-{upstream,downstream,control,edge}"
 
-  env:chainsaw-federation:
-    desc: "Run the federation Chainsaw e2e test against the control/edge environment"
+  env:chainsaw:
+    desc: "Run the full Chainsaw e2e suite (replicator + federation + full-chain) against the environment"
     deps:
       - env:chainsaw-prepare-kubeconfigs
     cmds:
       # Chainsaw needs *a* default KUBECONFIG to initialize its client even
-      # though this test only ever addresses the "control"/"edge" clusters
-      # by name (spec.clusters) - point it at the control kubeconfig we just
-      # exported.
-      - cd test/e2e && KUBECONFIG=kubeconfig-control chainsaw test federation/
+      # though each suite addresses its clusters by name (spec.clusters) -
+      # point it at the control kubeconfig we just exported. `.` runs every
+      # suite under test/e2e (alias, display-annotations, zones-and-records,
+      # federation, full-chain).
+      - cd test/e2e && KUBECONFIG=kubeconfig-control chainsaw test .
 
   env:down:
-    desc: "Tear down both clusters"
+    desc: "Tear down all clusters (upstream + control + edge)"
     cmds:
+      - task: test-infra:delete-kind
+        vars:
+          CLUSTER_NAME: "{{.UPSTREAM_CLUSTER_NAME}}"
       # NOTE: calling the leaf `delete-kind` task directly (not the
       # `cluster-down`/`down` wrapper) - go-task does not forward
       # caller-supplied `vars:` through a wrapper task's own un-parameterized
@@ -253,4 +316,4 @@ tasks:
       - task: test-infra:delete-kind
         vars:
           CLUSTER_NAME: "{{.EDGE_CLUSTER_NAME}}"
-      - rm -f {{.RUSTFS_NODEPORT_FILE}} {{.ENV_KUBECONFIG}}
+      - rm -f {{.RUSTFS_NODEPORT_FILE}} {{.ENV_KUBECONFIG}} {{.CONTROL_INCLUSTER_KUBECONFIG}}

--- a/config/agent/manager.yaml
+++ b/config/agent/manager.yaml
@@ -159,14 +159,35 @@ spec:
             exec pdns_server \
               --api-key="$(cat /run/pdns/api-key)" --api=yes --webserver-port=8082
         securityContext:
-          runAsUser: 953
-          runAsGroup: 953
+          # NOTE: pdns must start as root (uid 0) despite `drop: ALL` +
+          # `add: NET_BIND_SERVICE` below - Kubernetes/containerd does not
+          # populate the Linux *ambient* capability set when translating
+          # SecurityContext into the container's OCI spec, and without
+          # ambient capabilities, added capabilities do NOT survive an
+          # exec() into a normal (non-file-capability) binary for a non-root
+          # UID - see capabilities(7). Concretely: running this container as
+          # `runAsUser: 953` with `capabilities.add: [NET_BIND_SERVICE]`
+          # results in `pdns_server` getting a Permission denied binding to
+          # UDP/TCP :53, because the capability never survives past the
+          # `sh -c` -> `pdns_server` exec chain. Root is exempt from that
+          # exec-time capability-computation rule, so we start as root and
+          # let PowerDNS's own `setuid=pdns`/`setgid=pdns` in pdns.conf drop
+          # privileges internally after binding - the pattern the upstream
+          # image is designed around. SETUID/SETGID are added so pdns can
+          # perform that internal drop under `drop: ALL`. DAC_OVERRIDE is
+          # needed too: `drop: ALL` also strips root's usual free pass
+          # around filesystem permission checks, and /run/pdns (the shared
+          # emptyDir also used for the control socket) is chowned to
+          # 953:953 by the init-dirs initContainer - without DAC_OVERRIDE
+          # root can't create the pdns.controlsocket file there.
+          runAsUser: 0
+          runAsGroup: 0
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           capabilities:
             drop:
             - "ALL"
-            add: ["NET_BIND_SERVICE"]
+            add: ["NET_BIND_SERVICE", "SETUID", "SETGID", "DAC_OVERRIDE"]
       - name: pdns-recursor
         image: powerdns/pdns-recursor-51:latest
         imagePullPolicy: IfNotPresent
@@ -219,10 +240,30 @@ spec:
             drop:
               - "ALL"
         env:
-          - name: LS_INSTANCE
+          - name: POD_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          # CLUSTER_ID disambiguates Lightningstream's per-instance identity
+          # across separate clusters sharing one S3 bucket (see
+          # config/overlays/agent-powerdns-federated + Taskfile.yaml
+          # env:s3-secret). Pod name alone (e.g. "pdns-auth-0") is NOT
+          # unique across clusters - the control and edge StatefulSets both
+          # name their first replica "pdns-auth-0", so without this,
+          # Lightningstream on both clusters reports the same LS_INSTANCE
+          # and each treats the other's uploads as "its own", never
+          # merging/replicating. Optional and empty by default so this base
+          # stays a no-op for the single-cluster config/overlays/agent-powerdns
+          # overlay, where pod name alone is already unique (multiple
+          # replicas in one cluster/one bucket).
+          - name: CLUSTER_ID
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: cluster_id
+                optional: true
+          - name: LS_INSTANCE
+            value: "$(CLUSTER_ID)$(POD_NAME)"
           - name: S3_ACCESS_KEY
             valueFrom:
               secretKeyRef:

--- a/config/dependencies/rustfs/helmrelease.yaml
+++ b/config/dependencies/rustfs/helmrelease.yaml
@@ -1,0 +1,66 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rustfs
+  namespace: rustfs-system
+spec:
+  interval: 5m
+  timeout: 10m
+
+  chart:
+    spec:
+      chart: rustfs
+      version: 0.1.x  # Use latest 0.1.x version
+      sourceRef:
+        kind: HelmRepository
+        name: rustfs
+        namespace: rustfs-system
+      interval: 1h
+
+  values:
+    auth:
+      accessKey: "dns-federation"
+      secretKey: "dns-federation-secret"
+
+    # NOTE: the pinned chart version below (0.1.x) predates this chart's
+    # `setup.buckets` bucket-provisioning hook (added around 0.10.x) - so
+    # that value is silently ignored here. The "lightningstream" bucket is
+    # instead created explicitly by Taskfile.yaml's env:rustfs-up (via a
+    # one-off `aws s3 mb` pod), which works regardless of chart version.
+    # Lightningstream itself never creates its own bucket - without one it
+    # just polls "list snapshots" forever, logging "Volume not found".
+
+    config:
+      logLevel: "info"
+
+    # Small local footprint - this backs a single test zone's LMDB snapshots,
+    # not a production workload.
+    dataPersistence:
+      size: 2Gi
+    logsPersistence:
+      size: 1Gi
+
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+
+    # NodePort (not ClusterIP): the edge cluster reaches this Service from a
+    # different kind cluster over the shared "kind" Docker network, using the
+    # control-plane node's container name + the NodePort assigned here.
+    # NodePort is intentionally left unset so Kubernetes allocates it
+    # dynamically - see the test-infra fix for concurrent-cluster NodePorts.
+    service:
+      type: NodePort
+
+  install:
+    crds: CreateReplace
+    createNamespace: false
+
+  upgrade:
+    crds: CreateReplace
+
+  uninstall:
+    keepHistory: false

--- a/config/dependencies/rustfs/helmrepository.yaml
+++ b/config/dependencies/rustfs/helmrepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: rustfs
+  namespace: rustfs-system
+spec:
+  type: oci
+  interval: 1h
+  url: oci://registry-1.docker.io/cloudpirates
+  timeout: 3m

--- a/config/dependencies/rustfs/kustomization.yaml
+++ b/config/dependencies/rustfs/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/config/dependencies/rustfs/namespace.yaml
+++ b/config/dependencies/rustfs/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rustfs-system
+  labels:
+    app.kubernetes.io/name: rustfs
+    app.kubernetes.io/component: storage

--- a/config/overlays/agent-powerdns-federated/kustomization.yaml
+++ b/config/overlays/agent-powerdns-federated/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: dns-agent-system
+
+resources:
+  - ../../agent
+
+components:
+  - ../../agent/components/namespace
+
+# Unlike config/overlays/agent-powerdns, this overlay does NOT ship its own
+# MinIO instance or a static s3-credentials Secret: it's used for both the
+# "control" and "edge" clusters in the local PowerDNS Lightningstream
+# federation environment (see Taskfile.yaml env:* tasks), and the two
+# clusters need different s3-credentials endpoint_url values (in-cluster
+# RustFS Service vs. a cross-cluster NodePort discovered at apply time).
+# The Taskfile applies s3-credentials with `kubectl create secret ... | apply`
+# after this kustomization and after RustFS is up.

--- a/config/samples/federation/dnszone-example.yaml
+++ b/config/samples/federation/dnszone-example.yaml
@@ -1,0 +1,44 @@
+# Applied to the "control" cluster only (see Taskfile.yaml env:up) to exercise
+# PowerDNS Lightningstream edge federation end-to-end: the DNSRecordSet below
+# is written to the control cluster's pdns-auth via dns-operator, published to
+# the shared RustFS bucket by lightningstream, and should appear at the
+# "edge" cluster's pdns-auth once its lightningstream sidecar pulls the
+# snapshot - without ever being applied to the edge cluster directly.
+apiVersion: dns.networking.miloapis.com/v1alpha1
+kind: DNSZoneClass
+metadata:
+  name: powerdns
+spec:
+  controllerName: powerdns
+  nameServerPolicy:
+    mode: Static
+    static:
+      servers: ["ns1.example.net.", "ns2.example.net."]
+---
+apiVersion: dns.networking.miloapis.com/v1alpha1
+kind: DNSZone
+metadata:
+  name: example-com
+  namespace: default
+spec:
+  domainName: example.com
+  dnsZoneClassName: powerdns
+---
+apiVersion: dns.networking.miloapis.com/v1alpha1
+kind: DNSRecordSet
+metadata:
+  name: www-a
+  namespace: default
+spec:
+  dnsZoneRef:
+    name: example-com
+  recordType: A
+  records:
+    - name: www
+      a:
+        content: "192.0.2.10"
+      ttl: 300
+    - name: www
+      a:
+        content: "192.0.2.11"
+      ttl: 300

--- a/test/e2e/alias/chainsaw-test.yaml
+++ b/test/e2e/alias/chainsaw-test.yaml
@@ -188,6 +188,11 @@ spec:
             namespace: default
           spec:
             restartPolicy: Never
+            # Default 30s grace period exceeds chainsaw's delete timeout, so
+            # cleanup of this pod times out ("context deadline exceeded") on
+            # the shared control cluster. Terminate immediately (same pattern
+            # as the federation/full-chain suites).
+            terminationGracePeriodSeconds: 0
             containers:
             - name: dns
               image: infoblox/dnstools:latest

--- a/test/e2e/federation/chainsaw-test.yaml
+++ b/test/e2e/federation/chainsaw-test.yaml
@@ -1,0 +1,297 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: dns-operator-federation
+spec:
+  timeouts:
+    # The edge-replication script step below polls for a few minutes waiting
+    # for Lightningstream to sync; give exec plenty of headroom.
+    exec: 240s
+  clusters:
+    control:
+      kubeconfig: ../kubeconfig-control
+    edge:
+      kubeconfig: ../kubeconfig-edge
+  cluster: control
+  steps:
+  - name: Prereq - create DNSZoneClass on control
+    try:
+    - create:
+        cluster: control
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZoneClass
+          metadata:
+            name: powerdns-federation
+          spec:
+            controllerName: powerdns
+            nameServerPolicy:
+              mode: Static
+              static:
+                servers:
+                - ns1.fed-test.example.
+                - ns2.fed-test.example.
+            defaults:
+              defaultTTL: 300
+    - assert:
+        cluster: control
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZoneClass
+          metadata:
+            name: powerdns-federation
+
+  - name: Create DNSZone on control
+    try:
+    - create:
+        cluster: control
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZone
+          metadata:
+            name: fed-test-example
+          spec:
+            domainName: fed-test.example
+            dnsZoneClassName: powerdns-federation
+    - assert:
+        cluster: control
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZone
+          metadata:
+            name: fed-test-example
+          # NOTE: unlike the upstream/replicator topology exercised by
+          # test/e2e/zones-and-records (which sets Accepted/Programmed
+          # conditions on DNSZone via dnszone_replicator_controller.go),
+          # this federation environment's agent runs dns-operator with
+          # --role=downstream only (see config/agent/manager.yaml), which
+          # reconciles DNSZone via dnszone_downstream_controller.go - that
+          # controller does not set status.conditions on DNSZone at all, it
+          # only populates status.nameservers from the DNSZoneClass. The
+          # Accepted/Programmed conditions this test cares about instead
+          # live on DNSRecordSet (asserted below), which downstream *does*
+          # set via dnsrecordset_downstream_controller.go /
+          # dnsrecordset_powerdns_controller.go.
+          status:
+            nameservers:
+            - ns1.fed-test.example.
+            - ns2.fed-test.example.
+
+  - name: Create DNSRecordSet on control
+    try:
+    - create:
+        cluster: control
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSRecordSet
+          metadata:
+            name: edge-a
+          spec:
+            dnsZoneRef:
+              name: fed-test-example
+            recordType: A
+            records:
+            - name: edge
+              ttl: 5
+              a:
+                content: 192.0.2.10
+    - assert:
+        cluster: control
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSRecordSet
+          metadata:
+            name: edge-a
+            ownerReferences:
+            - apiVersion: dns.networking.miloapis.com/v1alpha1
+              kind: DNSZone
+              name: fed-test-example
+          status:
+            (conditions[?type == 'Accepted']):
+            - status: "True"
+            (conditions[?type == 'Programmed']):
+            - status: "True"
+
+  - name: DNS query on control confirms the record is programmed locally
+    try:
+    - create:
+        cluster: control
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: dnsutils
+            namespace: default
+          spec:
+            restartPolicy: Never
+            # Default 30s termination grace period exceeds chainsaw's
+            # default 15s delete timeout, spuriously failing the explicit
+            # Teardown step below.
+            terminationGracePeriodSeconds: 0
+            containers:
+            - name: dns
+              image: infoblox/dnstools:latest
+              command: ["sleep", "3600"]
+    - assert:
+        cluster: control
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: dnsutils
+            namespace: default
+          status:
+            phase: Running
+    - script:
+        cluster: control
+        content: |
+          set -eu
+          kubectl wait --for=condition=Ready --timeout=120s -n default pod/dnsutils
+          kubectl -n default exec pod/dnsutils -- sh -c \
+            "dig @pdns-auth.dns-agent-system.svc.cluster.local edge.fed-test.example A +short | grep -E '^192\\.0\\.2\\.10$'"
+
+  - name: DNS query on edge confirms Lightningstream replication (without the CR ever existing on edge)
+    try:
+    - script:
+        cluster: edge
+        skipCommandOutput: true
+        content: |
+          set -eu
+          # The edge cluster never receives the DNSZone/DNSRecordSet CRs
+          # directly - PowerDNS on edge only learns about this record via
+          # Lightningstream syncing LMDB snapshots through the shared RustFS
+          # bucket, which happens on a polling interval, not instantly.
+          # Poll for a few minutes rather than asserting immediately.
+          if ! kubectl -n default get pod dnsutils >/dev/null 2>&1; then
+            kubectl -n default run dnsutils --image=infoblox/dnstools:latest --restart=Never \
+              --overrides='{"spec":{"terminationGracePeriodSeconds":0}}' --command -- sh -c 'sleep 3600'
+          fi
+          kubectl wait --for=condition=Ready --timeout=120s -n default pod/dnsutils
+
+          attempts=18
+          delay=10
+          i=0
+          while [ "$i" -lt "$attempts" ]; do
+            out=$(kubectl -n default exec pod/dnsutils -- sh -c \
+              "dig @pdns-auth.dns-agent-system.svc.cluster.local edge.fed-test.example A +short +time=2 +tries=1" || true)
+            echo "[edge attempt $((i+1))/$attempts] dig result: '${out}'"
+            if [ "$out" = "192.0.2.10" ]; then
+              echo "Record replicated to edge PowerDNS."
+              exit 0
+            fi
+            i=$((i+1))
+            sleep "$delay"
+          done
+          echo "Record never replicated to edge PowerDNS after $((attempts*delay))s" >&2
+          exit 1
+
+  - name: Confirm DNSZone on control was never created on edge
+    try:
+    - error:
+        cluster: edge
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZone
+          metadata:
+            name: fed-test-example
+
+  - name: Delete DNSRecordSet on control and confirm it eventually disappears from edge too
+    try:
+    - delete:
+        cluster: control
+        ref:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSRecordSet
+          name: edge-a
+    - script:
+        cluster: control
+        content: |
+          set -eu
+          if kubectl -n default get dnsrecordset edge-a >/dev/null 2>&1; then
+            echo "control DNSRecordSet still exists" >&2
+            exit 1
+          fi
+    - script:
+        cluster: control
+        content: |
+          set -eu
+          kubectl -n default exec pod/dnsutils -- sh -lc '
+          out=$(dig @pdns-auth.dns-agent-system.svc.cluster.local edge.fed-test.example A +short +tries=1 +time=2);
+          printf ">>>%s<<<\n" "$out";
+          [ -z "$out" ] && echo "EMPTY" || echo "NONEMPTY"
+          '
+    - script:
+        cluster: edge
+        skipCommandOutput: true
+        content: |
+          set -eu
+          attempts=18
+          delay=10
+          i=0
+          while [ "$i" -lt "$attempts" ]; do
+            out=$(kubectl -n default exec pod/dnsutils -- sh -c \
+              "dig @pdns-auth.dns-agent-system.svc.cluster.local edge.fed-test.example A +short +time=2 +tries=1" || true)
+            echo "[edge cleanup attempt $((i+1))/$attempts] dig result: '${out}'"
+            if [ -z "$out" ]; then
+              echo "Record removal replicated to edge PowerDNS."
+              exit 0
+            fi
+            i=$((i+1))
+            sleep "$delay"
+          done
+          echo "Record deletion never replicated to edge PowerDNS after $((attempts*delay))s" >&2
+          exit 1
+
+  - name: Teardown
+    try:
+    - delete:
+        cluster: control
+        ref:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZone
+          name: fed-test-example
+        expect:
+        - match:
+            apiVersion: dns.networking.miloapis.com/v1alpha1
+            kind: DNSZone
+          check:
+            ($error == null): true
+    - delete:
+        cluster: control
+        ref:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZoneClass
+          name: powerdns-federation
+        expect:
+        - match:
+            apiVersion: dns.networking.miloapis.com/v1alpha1
+            kind: DNSZoneClass
+          check:
+            ($error == null): true
+    - delete:
+        cluster: control
+        ref:
+          apiVersion: v1
+          kind: Pod
+          namespace: default
+          name: dnsutils
+        expect:
+        - match:
+            apiVersion: v1
+            kind: Pod
+          check:
+            ($error == null): true
+    - delete:
+        cluster: edge
+        ref:
+          apiVersion: v1
+          kind: Pod
+          namespace: default
+          name: dnsutils
+        expect:
+        - match:
+            apiVersion: v1
+            kind: Pod
+          check:
+            ($error == null): true

--- a/test/e2e/federation/chainsaw-test.yaml
+++ b/test/e2e/federation/chainsaw-test.yaml
@@ -121,7 +121,7 @@ spec:
           apiVersion: v1
           kind: Pod
           metadata:
-            name: dnsutils
+            name: dnsutils-fed
             namespace: default
           spec:
             restartPolicy: Never
@@ -139,7 +139,7 @@ spec:
           apiVersion: v1
           kind: Pod
           metadata:
-            name: dnsutils
+            name: dnsutils-fed
             namespace: default
           status:
             phase: Running
@@ -147,8 +147,8 @@ spec:
         cluster: control
         content: |
           set -eu
-          kubectl wait --for=condition=Ready --timeout=120s -n default pod/dnsutils
-          kubectl -n default exec pod/dnsutils -- sh -c \
+          kubectl wait --for=condition=Ready --timeout=120s -n default pod/dnsutils-fed
+          kubectl -n default exec pod/dnsutils-fed -- sh -c \
             "dig @pdns-auth.dns-agent-system.svc.cluster.local edge.fed-test.example A +short | grep -E '^192\\.0\\.2\\.10$'"
 
   - name: DNS query on edge confirms Lightningstream replication (without the CR ever existing on edge)
@@ -163,17 +163,17 @@ spec:
           # Lightningstream syncing LMDB snapshots through the shared RustFS
           # bucket, which happens on a polling interval, not instantly.
           # Poll for a few minutes rather than asserting immediately.
-          if ! kubectl -n default get pod dnsutils >/dev/null 2>&1; then
-            kubectl -n default run dnsutils --image=infoblox/dnstools:latest --restart=Never \
+          if ! kubectl -n default get pod dnsutils-fed >/dev/null 2>&1; then
+            kubectl -n default run dnsutils-fed --image=infoblox/dnstools:latest --restart=Never \
               --overrides='{"spec":{"terminationGracePeriodSeconds":0}}' --command -- sh -c 'sleep 3600'
           fi
-          kubectl wait --for=condition=Ready --timeout=120s -n default pod/dnsutils
+          kubectl wait --for=condition=Ready --timeout=120s -n default pod/dnsutils-fed
 
           attempts=18
           delay=10
           i=0
           while [ "$i" -lt "$attempts" ]; do
-            out=$(kubectl -n default exec pod/dnsutils -- sh -c \
+            out=$(kubectl -n default exec pod/dnsutils-fed -- sh -c \
               "dig @pdns-auth.dns-agent-system.svc.cluster.local edge.fed-test.example A +short +time=2 +tries=1" || true)
             echo "[edge attempt $((i+1))/$attempts] dig result: '${out}'"
             if [ "$out" = "192.0.2.10" ]; then
@@ -216,7 +216,7 @@ spec:
         cluster: control
         content: |
           set -eu
-          kubectl -n default exec pod/dnsutils -- sh -lc '
+          kubectl -n default exec pod/dnsutils-fed -- sh -lc '
           out=$(dig @pdns-auth.dns-agent-system.svc.cluster.local edge.fed-test.example A +short +tries=1 +time=2);
           printf ">>>%s<<<\n" "$out";
           [ -z "$out" ] && echo "EMPTY" || echo "NONEMPTY"
@@ -230,7 +230,7 @@ spec:
           delay=10
           i=0
           while [ "$i" -lt "$attempts" ]; do
-            out=$(kubectl -n default exec pod/dnsutils -- sh -c \
+            out=$(kubectl -n default exec pod/dnsutils-fed -- sh -c \
               "dig @pdns-auth.dns-agent-system.svc.cluster.local edge.fed-test.example A +short +time=2 +tries=1" || true)
             echo "[edge cleanup attempt $((i+1))/$attempts] dig result: '${out}'"
             if [ -z "$out" ]; then
@@ -275,7 +275,7 @@ spec:
           apiVersion: v1
           kind: Pod
           namespace: default
-          name: dnsutils
+          name: dnsutils-fed
         expect:
         - match:
             apiVersion: v1
@@ -288,7 +288,7 @@ spec:
           apiVersion: v1
           kind: Pod
           namespace: default
-          name: dnsutils
+          name: dnsutils-fed
         expect:
         - match:
             apiVersion: v1

--- a/test/e2e/full-chain/chainsaw-test.yaml
+++ b/test/e2e/full-chain/chainsaw-test.yaml
@@ -1,0 +1,337 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+#
+# End-to-end proof of the whole production chain in one test:
+#
+#   upstream (replicator)  --push-->  control (downstream agent + PowerDNS)
+#     --Lightningstream/RustFS snapshot-->  edge (PowerDNS)
+#
+# A DNSZone/DNSRecordSet is created ONLY on the upstream (control-plane)
+# cluster. The replicator copies it to the control cluster (which plays the
+# downstream agent role), whose dns-operator programs PowerDNS; Lightningstream
+# then replicates the LMDB snapshot to the edge cluster over the shared RustFS
+# bucket. The record is asserted to resolve on edge without any CR ever
+# existing there - the same end-to-end signal an operator relies on in
+# production.
+#
+# See test/e2e/zones-and-records (upstream->control replicator hop in
+# isolation) and test/e2e/federation (control->edge Lightningstream hop in
+# isolation); this suite chains both.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: dns-operator-full-chain
+spec:
+  timeouts:
+    # The edge-replication script polls for a few minutes waiting for
+    # Lightningstream to sync; give exec plenty of headroom.
+    exec: 240s
+  clusters:
+    upstream:
+      kubeconfig: ../kubeconfig-upstream
+    downstream:
+      kubeconfig: ../kubeconfig-downstream
+    edge:
+      kubeconfig: ../kubeconfig-edge
+  cluster: upstream
+  steps:
+  - name: Prereq - create DNSZoneClass in upstream
+    try:
+    - create:
+        cluster: upstream
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZoneClass
+          metadata:
+            name: powerdns-fullchain
+          spec:
+            controllerName: powerdns
+            nameServerPolicy:
+              mode: Static
+              static:
+                servers:
+                - ns1.fullchain.example.
+                - ns2.fullchain.example.
+            defaults:
+              defaultTTL: 300
+    - assert:
+        cluster: upstream
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZoneClass
+          metadata:
+            name: powerdns-fullchain
+
+  - name: Prereq - create DNSZoneClass in downstream
+    # The replicated DNSZone references this class by name on the downstream
+    # (control) cluster, so it must exist there too.
+    try:
+    - create:
+        cluster: downstream
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZoneClass
+          metadata:
+            name: powerdns-fullchain
+          spec:
+            controllerName: powerdns
+            nameServerPolicy:
+              mode: Static
+              static:
+                servers:
+                - ns1.fullchain.example.
+                - ns2.fullchain.example.
+            defaults:
+              defaultTTL: 300
+    - assert:
+        cluster: downstream
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZoneClass
+          metadata:
+            name: powerdns-fullchain
+
+  - name: Create DNSZone upstream
+    try:
+    - create:
+        cluster: upstream
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZone
+          metadata:
+            name: fullchain-example
+          spec:
+            domainName: fullchain.example
+            dnsZoneClassName: powerdns-fullchain
+    - assert:
+        cluster: upstream
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZone
+          metadata:
+            name: fullchain-example
+
+  - name: Confirm DNSZone replicated to downstream (control)
+    try:
+    - script:
+        cluster: upstream
+        skipCommandOutput: true
+        skipLogOutput: true
+        content: |
+          kubectl get ns $NAMESPACE -o json
+        outputs:
+        - name: downstreamNamespaceName
+          value: (join('-', ['ns', json_parse($stdout).metadata.uid]))
+    - assert:
+        cluster: downstream
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZone
+          metadata:
+            name: fullchain-example
+            namespace: ($downstreamNamespaceName)
+
+  - name: Create DNSRecordSet upstream
+    try:
+    - create:
+        cluster: upstream
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSRecordSet
+          metadata:
+            name: api-fullchain
+          spec:
+            dnsZoneRef:
+              name: fullchain-example
+            recordType: A
+            records:
+            - name: api
+              ttl: 5
+              a:
+                content: 192.0.2.50
+    - assert:
+        cluster: upstream
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSRecordSet
+          metadata:
+            name: api-fullchain
+            ownerReferences:
+            - apiVersion: dns.networking.miloapis.com/v1alpha1
+              kind: DNSZone
+              name: fullchain-example
+
+  - name: Confirm DNSRecordSet Accepted/Programmed upstream
+    # These conditions on the upstream CR only flip True once the replicator
+    # has pushed the record to control and control's agent has programmed
+    # PowerDNS - so this asserts the upstream->control hop succeeded.
+    try:
+    - assert:
+        cluster: upstream
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSRecordSet
+          metadata:
+            name: api-fullchain
+          status:
+            (conditions[?type == 'Accepted']):
+            - status: "True"
+            (conditions[?type == 'Programmed']):
+            - status: "True"
+
+  - name: DNS query on control confirms the record is programmed locally
+    try:
+    - create:
+        cluster: downstream
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: dnsutils-fullchain
+            namespace: default
+          spec:
+            restartPolicy: Never
+            # Default 30s termination grace period exceeds chainsaw's default
+            # 15s delete timeout, spuriously failing the Teardown step below.
+            terminationGracePeriodSeconds: 0
+            containers:
+            - name: dns
+              image: infoblox/dnstools:latest
+              command: ["sleep", "3600"]
+    - assert:
+        cluster: downstream
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: dnsutils-fullchain
+            namespace: default
+          status:
+            phase: Running
+    - script:
+        cluster: downstream
+        content: |
+          set -eu
+          kubectl wait --for=condition=Ready --timeout=120s -n default pod/dnsutils-fullchain
+          kubectl -n default exec pod/dnsutils-fullchain -- sh -c \
+            "dig @pdns-auth.dns-agent-system.svc.cluster.local api.fullchain.example A +short | grep -E '^192\\.0\\.2\\.50$'"
+
+  - name: DNS query on edge confirms the full upstream->edge chain via Lightningstream
+    try:
+    - script:
+        cluster: edge
+        skipCommandOutput: true
+        content: |
+          set -eu
+          # The edge cluster never receives the DNSZone/DNSRecordSet CRs and
+          # was never touched by the replicator - PowerDNS on edge only learns
+          # this record via Lightningstream syncing LMDB snapshots through the
+          # shared RustFS bucket, on a polling interval. Poll for a few minutes.
+          if ! kubectl -n default get pod dnsutils-fullchain >/dev/null 2>&1; then
+            kubectl -n default run dnsutils-fullchain --image=infoblox/dnstools:latest --restart=Never \
+              --overrides='{"spec":{"terminationGracePeriodSeconds":0}}' --command -- sh -c 'sleep 3600'
+          fi
+          kubectl wait --for=condition=Ready --timeout=120s -n default pod/dnsutils-fullchain
+
+          attempts=18
+          delay=10
+          i=0
+          while [ "$i" -lt "$attempts" ]; do
+            out=$(kubectl -n default exec pod/dnsutils-fullchain -- sh -c \
+              "dig @pdns-auth.dns-agent-system.svc.cluster.local api.fullchain.example A +short +time=2 +tries=1" || true)
+            echo "[edge attempt $((i+1))/$attempts] dig result: '${out}'"
+            if [ "$out" = "192.0.2.50" ]; then
+              echo "Record created on upstream reached edge PowerDNS."
+              exit 0
+            fi
+            i=$((i+1))
+            sleep "$delay"
+          done
+          echo "Record never reached edge PowerDNS after $((attempts*delay))s" >&2
+          exit 1
+
+  - name: Confirm the DNSZone never existed on edge
+    try:
+    - error:
+        cluster: edge
+        resource:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZone
+          metadata:
+            name: fullchain-example
+
+  - name: Teardown - delete upstream resources; replication removes them downstream and on edge
+    try:
+    - delete:
+        cluster: upstream
+        ref:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSRecordSet
+          name: api-fullchain
+        expect:
+        - match:
+            apiVersion: dns.networking.miloapis.com/v1alpha1
+            kind: DNSRecordSet
+          check:
+            ($error == null): true
+    - delete:
+        cluster: upstream
+        ref:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZone
+          name: fullchain-example
+        expect:
+        - match:
+            apiVersion: dns.networking.miloapis.com/v1alpha1
+            kind: DNSZone
+          check:
+            ($error == null): true
+    - delete:
+        cluster: downstream
+        ref:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZoneClass
+          name: powerdns-fullchain
+        expect:
+        - match:
+            apiVersion: dns.networking.miloapis.com/v1alpha1
+            kind: DNSZoneClass
+          check:
+            ($error == null): true
+    - delete:
+        cluster: upstream
+        ref:
+          apiVersion: dns.networking.miloapis.com/v1alpha1
+          kind: DNSZoneClass
+          name: powerdns-fullchain
+        expect:
+        - match:
+            apiVersion: dns.networking.miloapis.com/v1alpha1
+            kind: DNSZoneClass
+          check:
+            ($error == null): true
+    - delete:
+        cluster: downstream
+        ref:
+          apiVersion: v1
+          kind: Pod
+          namespace: default
+          name: dnsutils-fullchain
+        expect:
+        - match:
+            apiVersion: v1
+            kind: Pod
+          check:
+            ($error == null): true
+    - delete:
+        cluster: edge
+        ref:
+          apiVersion: v1
+          kind: Pod
+          namespace: default
+          name: dnsutils-fullchain
+        expect:
+        - match:
+            apiVersion: v1
+            kind: Pod
+          check:
+            ($error == null): true

--- a/test/e2e/zones-and-records/chainsaw-test.yaml
+++ b/test/e2e/zones-and-records/chainsaw-test.yaml
@@ -236,6 +236,11 @@ spec:
             namespace: default
           spec:
             restartPolicy: Never
+            # Default 30s grace period exceeds chainsaw's delete timeout, so
+            # cleanup of this pod times out ("context deadline exceeded") on
+            # the shared control cluster. Terminate immediately (same pattern
+            # as the federation/full-chain suites).
+            terminationGracePeriodSeconds: 0
             containers:
             - name: dns
               image: infoblox/dnstools:latest


### PR DESCRIPTION
## Summary

Today dns-operator's e2e setup only validates the replicator → downstream Kubernetes-API path against a single PowerDNS instance. It never validates the mechanism that actually gets zone data to edge PoPs in production — **PowerDNS Lightningstream** replicating snapshots over shared object storage — nor the full chain end-to-end.

This PR adds a three-cluster local environment that reproduces the whole production DNS path and wires it into CI, backed by [RustFS](https://rustfs.com) as a local S3-compatible store standing in for GCS. The clusters are [`datum-cloud/test-infra`](https://github.com/datum-cloud/test-infra) kind clusters (same pattern `milo-os/activity` uses):

```
upstream (replicator)  ──push──▶  control (downstream agent + PowerDNS + Lightningstream + RustFS)  ──S3 snapshot──▶  edge (PowerDNS)
```

The `control` cluster plays two roles at once — the replicator's `downstream` target and Lightningstream's `control` (snapshot source) — mirroring how a production PoP both receives replicated zone data and re-publishes it to edges.

```bash
export TASK_X_REMOTE_TASKFILES=1
task env:up          # upstream + control + edge clusters, deploy a sample zone
task env:dns-check   # confirm the sample record replicated from control to edge
task env:down        # tear down all three clusters

# CI-style run (no sample data, then the full suite):
task env:stack-up    # bring up the full chain
task env:chainsaw    # run every Chainsaw suite against it
```

Two end-to-end signals are validated purely through replication, without the CR ever existing on the destination cluster:

- **`test/e2e/full-chain`** — a DNSZone/DNSRecordSet created *only* on `upstream` is replicated to `control`, programmed into PowerDNS, and resolves on `edge` via Lightningstream. This is the whole production chain in one test.
- **`test/e2e/federation`** — the `control → edge` Lightningstream hop in isolation.

## CI

`.github/workflows/e2e.yml` is reworked into a single job that stands up the full three-cluster environment via Task and runs **every** suite under `test/e2e` against it — the replicator suites (`alias`, `display-annotations`, `zones-and-records`), the Lightningstream suite (`federation`), and the end-to-end suite (`full-chain`). The previous single upstream/downstream `bootstrap-e2e` path is replaced. A disk-reclamation step runs first, since three test-infra clusters' worth of images otherwise overflow the runner's OS disk and thrash `kind load`.

## What's included

- **`Taskfile.yaml`** — brings up/tears down all three clusters, RustFS, and the replicator wiring, reusing existing `Makefile` targets rather than reimplementing kind/kustomize logic. New tasks: `env:upstream-up` (replicator, pointed at `control` via a `downstream-kubeconfig` secret), `env:stack-up` (full chain, no sample data — used by CI), and `env:chainsaw` (runs the whole `test/e2e` suite).
- **`config/dependencies/rustfs/`** — Flux `HelmRelease` deploying RustFS as the shared object store.
- **`config/overlays/agent-powerdns-federated/`** — agent overlay shared by `control` and `edge`; S3 credentials are supplied dynamically instead of the static local MinIO the older single-cluster overlay used.
- **`config/agent/manager.yaml`** (shared with the existing `config/overlays/agent-powerdns` overlay) — two real bugs fixed while building this out, both applicable beyond just this new environment:
  - PowerDNS couldn't bind port 53 as non-root: Kubernetes doesn't populate the Linux *ambient* capability set, so an added `NET_BIND_SERVICE` capability doesn't survive the `sh -c` → `pdns_server` exec chain for a non-root UID. Now starts as root and lets PowerDNS's own `setuid`/`setgid` config drop privileges internally, which is the pattern the upstream image is designed around.
  - Lightningstream's per-instance identity was derived only from pod name, which collides across clusters (`pdns-auth-0` on both). Added a per-cluster `CLUSTER_ID` so two clusters sharing one bucket actually merge each other's snapshots instead of clobbering their own. No-op for the existing single-cluster overlay.
- **`test/e2e/full-chain/`** — Chainsaw suite validating the end-to-end `upstream → control → edge` path.
- **`test/e2e/federation/`** — Chainsaw suite validating the `control → edge` Lightningstream hop.
- **`test/e2e/{alias,zones-and-records}`** — their DNS query pods now set `terminationGracePeriodSeconds: 0` so chainsaw's cleanup doesn't time out deleting them on the now-shared `control` cluster (same pattern the federation/full-chain suites use).
- **`.github/workflows/e2e.yml`** — single full-environment e2e job (see CI above).

## Test plan

- [x] `task env:up` brings up all three clusters, RustFS, and the DNS platform from a cold start
- [x] Applying `config/samples/federation/dnszone-example.yaml` on `control` resolves locally and, after Lightningstream's snapshot interval, resolves on `edge` without ever being applied there
- [x] New `test/e2e/full-chain` suite passes (record created only on `upstream` resolves on `edge`)
- [x] New `test/e2e/federation` suite passes
- [x] Existing `test/e2e/{alias,display-annotations,zones-and-records}` suites pass against the shared `config/agent/manager.yaml` — all suites run green in the single e2e CI job on every push

## Dependencies

This environment tracks `datum-cloud/test-infra#35` (fixes hardcoded Envoy Gateway/Grafana NodePorts so multiple kind clusters can run concurrently on one host) — currently open as a draft. `Taskfile.yaml` pins `TEST_INFRA_REPO_REF` to that branch for now; should be bumped once #35 merges.

## Notes

The e2e job runs three full test-infra clusters (Flux/cert-manager/Kyverno/Envoy each) on one runner, which is resource-heavy; a disk-reclamation step keeps it within the runner's limits. If it proves flaky under load, the next lever is running `upstream`/`edge` as plain `kind` clusters so only `control` carries the heavy stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBWG1gyAFk8A6zChdKDSuZ
