### PR TITLE
fix: Resolve DNSZones on project control plane in webhook

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -287,6 +287,7 @@ func main() {
 
 		// Multicluster manager (serves mutating webhook for display annotations)
 		webhookServer := webhook.NewServer(webhookServerOptions)
+		webhookServer = dnswebhook.NewClusterAwareWebhookServer(webhookServer)
 		mcmgr, err := mcmanager.New(cfg, provider, ctrl.Options{
 			Scheme:                 scheme,
 			Metrics:                metricsServerOptions,
@@ -319,7 +320,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if err := dnswebhook.SetupDNSRecordSetWebhook(mcmgr.GetLocalManager()); err != nil {
+		if err := dnswebhook.SetupDNSRecordSetWebhook(mcmgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "DNSRecordSet")
 			os.Exit(1)
 		}

--- a/docs/enhancements/activity-integration.md
+++ b/docs/enhancements/activity-integration.md
@@ -102,7 +102,7 @@ The Activity Service translates audit logs and Kubernetes events into human-read
 | `dns.networking.miloapis.com/display-name` | `www.example.com` | Mutating webhook at create/update; replicator safety net |
 | `dns.networking.miloapis.com/display-value` | `192.0.2.10` | Same |
 
-Helpers live in `internal/display`. The webhook looks up the parent `DNSZone` to build the FQDN; if the zone is missing, annotations are left unset and policy fallbacks use `spec.records[0].name`.
+Helpers live in `internal/display`. The mutating webhook resolves the parent `DNSZone` on the project control plane (cluster-aware admission context); if the zone is missing or cluster resolution fails, annotations are left unset and the replicator acts as a safety net. Policy fallbacks use `spec.records[0].name`.
 
 ### Data Sources
 

--- a/internal/webhook/dnsrecordset_mutating.go
+++ b/internal/webhook/dnsrecordset_mutating.go
@@ -8,13 +8,17 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	mccontext "sigs.k8s.io/multicluster-runtime/pkg/context"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	dnsv1alpha1 "go.miloapis.com/dns-operator/api/v1alpha1"
 	"go.miloapis.com/dns-operator/internal/display"
@@ -23,6 +27,10 @@ import (
 // DNSRecordSetMutator stamps display-name / display-value annotations at
 // admission so ActivityPolicy create audits can include the FQDN.
 type DNSRecordSetMutator struct {
+	// Manager is optional; when set and cluster context is present, DNSZone
+	// lookups use the project control plane client.
+	Manager mcmanager.Manager
+	// Client is the local/deployment-cluster client used as fallback.
 	Client client.Client
 }
 
@@ -40,9 +48,10 @@ func (m *DNSRecordSetMutator) Default(ctx context.Context, obj runtime.Object) e
 		return nil
 	}
 
+	cl := m.clientForZoneLookup(ctx)
 	var zone dnsv1alpha1.DNSZone
 	key := types.NamespacedName{Namespace: rs.Namespace, Name: rs.Spec.DNSZoneRef.Name}
-	if err := m.Client.Get(ctx, key, &zone); err != nil {
+	if err := cl.Get(ctx, key, &zone); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
@@ -53,10 +62,39 @@ func (m *DNSRecordSetMutator) Default(ctx context.Context, obj runtime.Object) e
 	return nil
 }
 
+// clientForZoneLookup returns the project control plane client when cluster
+// context is available, otherwise the local Client.
+//
+// milo v0.7.4 engages cluster-scoped Projects as req.String() ("/projectname"),
+// while admission Extra carries the bare project name. Try both forms.
+func (m *DNSRecordSetMutator) clientForZoneLookup(ctx context.Context) client.Client {
+	if m.Manager == nil {
+		return m.Client
+	}
+	clusterName, ok := mccontext.ClusterFrom(ctx)
+	if !ok || clusterName == "" {
+		return m.Client
+	}
+
+	cl, err := m.Manager.GetCluster(ctx, clusterName)
+	if err != nil && !strings.HasPrefix(clusterName, "/") {
+		cl, err = m.Manager.GetCluster(ctx, "/"+clusterName)
+	}
+	if err != nil {
+		logf.FromContext(ctx).V(1).Info("falling back to local client for DNSZone lookup",
+			"cluster", clusterName, "error", err)
+		return m.Client
+	}
+	return cl.GetClient()
+}
+
 // SetupDNSRecordSetWebhook registers the mutating webhook with the manager.
-func SetupDNSRecordSetWebhook(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
+func SetupDNSRecordSetWebhook(mgr mcmanager.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr.GetLocalManager()).
 		For(&dnsv1alpha1.DNSRecordSet{}).
-		WithDefaulter(&DNSRecordSetMutator{Client: mgr.GetClient()}).
+		WithDefaulter(&DNSRecordSetMutator{
+			Manager: mgr,
+			Client:  mgr.GetLocalManager().GetClient(),
+		}).
 		Complete()
 }

--- a/internal/webhook/dnsrecordset_mutating_test.go
+++ b/internal/webhook/dnsrecordset_mutating_test.go
@@ -4,12 +4,18 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	mccontext "sigs.k8s.io/multicluster-runtime/pkg/context"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	dnsv1alpha1 "go.miloapis.com/dns-operator/api/v1alpha1"
 	"go.miloapis.com/dns-operator/internal/display"
@@ -143,4 +149,133 @@ func TestDNSRecordSetMutator_Default(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDNSRecordSetMutator_Default_projectClusterClient(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := dnsv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	zone := &dnsv1alpha1.DNSZone{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-zone", Namespace: "default"},
+		Spec:       dnsv1alpha1.DNSZoneSpec{DomainName: "project.example.com"},
+	}
+	projectClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(zone).Build()
+	localClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	rs := &dnsv1alpha1.DNSRecordSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "www", Namespace: "default"},
+		Spec: dnsv1alpha1.DNSRecordSetSpec{
+			DNSZoneRef: corev1.LocalObjectReference{Name: "my-zone"},
+			RecordType: dnsv1alpha1.RRTypeA,
+			Records:    []dnsv1alpha1.RecordEntry{{Name: "www", A: &dnsv1alpha1.ARecordSpec{Content: "192.0.2.10"}}},
+		},
+	}
+
+	t.Run("bare project name retries with slash prefix", func(t *testing.T) {
+		t.Parallel()
+		mgr := &fakeMCManager{
+			clusters: map[string]cluster.Cluster{
+				"/proj-1": &fakeCluster{client: projectClient},
+			},
+		}
+		m := &DNSRecordSetMutator{Manager: mgr, Client: localClient}
+		ctx := mccontext.WithCluster(context.Background(), "proj-1")
+		got := rs.DeepCopy()
+		if err := m.Default(ctx, got); err != nil {
+			t.Fatalf("Default: %v", err)
+		}
+		if want := "www.project.example.com"; got.Annotations[display.AnnotationDisplayName] != want {
+			t.Errorf("display-name = %q, want %q", got.Annotations[display.AnnotationDisplayName], want)
+		}
+		if want := "192.0.2.10"; got.Annotations[display.AnnotationDisplayValue] != want {
+			t.Errorf("display-value = %q, want %q", got.Annotations[display.AnnotationDisplayValue], want)
+		}
+	})
+
+	t.Run("getcluster failure falls back to local without failing admission", func(t *testing.T) {
+		t.Parallel()
+		mgr := &fakeMCManager{err: fmt.Errorf("cluster not engaged")}
+		m := &DNSRecordSetMutator{Manager: mgr, Client: localClient}
+		ctx := mccontext.WithCluster(context.Background(), "proj-1")
+		got := rs.DeepCopy()
+		if err := m.Default(ctx, got); err != nil {
+			t.Fatalf("Default: %v", err)
+		}
+		if got.Annotations != nil {
+			if _, ok := got.Annotations[display.AnnotationDisplayName]; ok {
+				t.Fatalf("unexpected display-name annotation: %v", got.Annotations)
+			}
+		}
+	})
+}
+
+func TestClusterNameFromExtra(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		extra map[string]authv1.ExtraValue
+		want  string
+	}{
+		{
+			name: "project parent",
+			extra: map[string]authv1.ExtraValue{
+				ParentTypeExtraKey: {"Project"},
+				ParentNameExtraKey: {"my-project"},
+			},
+			want: "my-project",
+		},
+		{
+			name: "organization parent ignored",
+			extra: map[string]authv1.ExtraValue{
+				ParentTypeExtraKey: {"Organization"},
+				ParentNameExtraKey: {"my-org"},
+			},
+			want: "",
+		},
+		{
+			name:  "empty extra",
+			extra: nil,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := clusterNameFromExtra(tt.extra); got != tt.want {
+				t.Errorf("clusterNameFromExtra = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// fakeMCManager implements only GetCluster for mutator tests.
+type fakeMCManager struct {
+	mcmanager.Manager
+	clusters map[string]cluster.Cluster
+	err      error
+}
+
+func (f *fakeMCManager) GetCluster(_ context.Context, name string) (cluster.Cluster, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if cl, ok := f.clusters[name]; ok {
+		return cl, nil
+	}
+	return nil, fmt.Errorf("cluster %q not found", name)
+}
+
+type fakeCluster struct {
+	cluster.Cluster
+	client client.Client
+}
+
+func (f *fakeCluster) GetClient() client.Client {
+	return f.client
 }

--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package webhook
+
+import (
+	"context"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	mccontext "sigs.k8s.io/multicluster-runtime/pkg/context"
+)
+
+// clusterAwareWebhookServer wraps a webhook.Server to inject the project
+// control plane cluster name from admission UserInfo.Extra into the context.
+// Copied locally because milo v0.7.4 does not expose pkg/webhook.
+type clusterAwareWebhookServer struct {
+	webhook.Server
+}
+
+var _ webhook.Server = &clusterAwareWebhookServer{}
+
+// NewClusterAwareWebhookServer wraps server so registered admission handlers
+// see mccontext.ClusterFrom(ctx) when the request targets a Project.
+func NewClusterAwareWebhookServer(server webhook.Server) webhook.Server {
+	return &clusterAwareWebhookServer{Server: server}
+}
+
+// Register wraps admission webhook handlers to inject cluster context.
+func (s *clusterAwareWebhookServer) Register(path string, hook http.Handler) {
+	if h, ok := hook.(*admission.Webhook); ok {
+		orig := h.Handler
+		h.Handler = admission.HandlerFunc(func(ctx context.Context, req admission.Request) admission.Response {
+			if clusterName := clusterNameFromExtra(req.UserInfo.Extra); clusterName != "" {
+				ctx = mccontext.WithCluster(ctx, clusterName)
+			}
+			return orig.Handle(ctx, req)
+		})
+	}
+	s.Server.Register(path, hook)
+}

--- a/internal/webhook/util.go
+++ b/internal/webhook/util.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package webhook
+
+import authv1 "k8s.io/api/authentication/v1"
+
+const (
+	// ParentNameExtraKey is set by Milo on project-scoped admission requests.
+	ParentNameExtraKey = "iam.miloapis.com/parent-name"
+	// ParentTypeExtraKey is set by Milo to identify the parent resource kind.
+	ParentTypeExtraKey = "iam.miloapis.com/parent-type"
+)
+
+// clusterNameFromExtra extracts the project control plane cluster name from
+// UserInfo.Extra. Only Project parents are treated as cluster context.
+func clusterNameFromExtra(extra map[string]authv1.ExtraValue) string {
+	if parentTypes, ok := extra[ParentTypeExtraKey]; !ok || len(parentTypes) == 0 || parentTypes[0] != "Project" {
+		return ""
+	}
+	if parentNames, ok := extra[ParentNameExtraKey]; ok && len(parentNames) > 0 && parentNames[0] != "" {
+		return parentNames[0]
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

The DNSRecordSet mutating webhook from #63 is registered and called on staging, but create audits still missed FQDNs. On project-scoped creates it looked up the parent `DNSZone` with the local deployment-cluster client. Zones live on the project control plane, so the Get returned NotFound, the mutator left annotations unset, and the replicator stamped them afterward. That matches what we saw on `hi.mdj-test.online`: Mozilla owned the create, `manager` added `display-name` later.

This follows the NSO / Milo notes pattern: wrap the webhook server so admission `UserInfo.Extra` (`parent-type=Project`, `parent-name`) becomes multicluster context, then resolve the zone with `mcmanager.GetCluster`. For milo v0.7.4, engaged cluster keys are `/projectname` while Extra carries the bare name, so lookup tries both. Zone NotFound or GetCluster failure still leaves annotations unset and does not fail admission; the replicator remains the safety net.

## Test plan

- [x] `go test ./internal/webhook/... ./internal/display/...`
- [ ] After merge + deploy: create a DNSRecordSet in a project and confirm `display-name` is present on the create response (before reconciler)
- [ ] Confirm managedFields attribute annotations to the admission/webhook path on create, not only later `manager` updates
- [ ] Activity create summary uses the FQDN when the activity pipeline is healthy
- [ ] Missing zone or unknown project still allows create (annotations unset, no admission failure)

Related to #62