### PR TITLE
feat: Ship DNSRecordSet MWC with the image bundle

### DIFF
--- a/config/components/admission-webhooks/README.md
+++ b/config/components/admission-webhooks/README.md
@@ -1,0 +1,53 @@
+# Admission webhooks (control-plane registration)
+
+Cross-cluster `MutatingWebhookConfiguration` for DNSRecordSet display
+annotations (`display-name` / `display-value`). The webhook **server** runs in
+the dns-operator manager; this bundle only registers admission with the
+control-plane apiserver.
+
+## Why a separate path
+
+The MWC must version with the image that serves it. Shipping it in
+`dns-operator-kustomize` under this path means an old tag (for example
+`v0.6.4`, which has no webhook server) cannot carry a registration Flux can
+apply. Hand-authoring the MWC in infra decoupled those versions and caused a
+production write outage when `failurePolicy: Fail` hit a build with nothing
+listening on `:9443` (see [#69](https://github.com/datum-cloud/dns-operator/issues/69)).
+
+This directory is **not** included in `config/default` or the replicator
+overlay. Same-cluster packaging for kind/e2e stays under `config/webhook/`.
+
+## Contents
+
+| Kind | Name | Notes |
+| ---- | ---- | ----- |
+| `MutatingWebhookConfiguration` | `dns-operator-mutating-webhook-configuration` | `failurePolicy: Ignore`; Service ref is `dns-operator-webhook-service` / `datum-dns-system` |
+
+No Service and no kustomize `namespace` transformer: Flux `targetNamespace`
+must not rewrite `clientConfig.service.namespace`.
+
+## Flux consumption (infra)
+
+Apply with the **same** `OCIRepository` (`dns-operator-kustomize`) and semver
+filter as the manager Deployment:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: core-control-plane-webhooks
+spec:
+  path: components/admission-webhooks
+  sourceRef:
+    kind: OCIRepository
+    name: dns-operator-kustomize
+  kubeConfig:
+    secretRef:
+      name: milo-configuration-kubeconfig
+  dependsOn:
+    - name: milo-apiserver
+      namespace: datum-system
+```
+
+Keep the webhook Service and TLS mounts on the deployment cluster as
+environment glue; do not copy the MWC YAML into the infra repo.

--- a/config/components/admission-webhooks/kustomization.yaml
+++ b/config/components/admission-webhooks/kustomization.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# Cross-cluster MutatingWebhookConfiguration for DNSRecordSet display
+# annotations. Applied to the control-plane apiserver via Flux; the webhook
+# Service lives on the deployment cluster (datum-dns-system).
+#
+# NOT composed into config/default or operator overlays. Consume with the same
+# OCIRepository semver as the manager image so registration cannot outrun the
+# binary that serves the webhook (see github.com/datum-cloud/dns-operator#69).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - mutating-webhook-configuration.yaml

--- a/config/components/admission-webhooks/mutating-webhook-configuration.yaml
+++ b/config/components/admission-webhooks/mutating-webhook-configuration.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# MutatingWebhookConfiguration for DNSRecordSet display annotations.
+#
+# clientConfig points at the webhook Service on the infra/deployment cluster.
+# Do not add kustomize nameReference/namespace transformers here: Flux
+# targetNamespace would rewrite the Service namespace and break cross-cluster
+# lookup. failurePolicy is Ignore so a missing webhook server degrades
+# activity FQDNs instead of blocking all DNSRecordSet writes.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: dns-operator-mutating-webhook-configuration
+webhooks:
+  - name: mdnsrecordset.kb.io
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: dns-operator-webhook-service
+        namespace: datum-dns-system
+        path: /mutate-dns-networking-miloapis-com-v1alpha1-dnsrecordset
+        port: 443
+    failurePolicy: Ignore
+    matchPolicy: Equivalent
+    sideEffects: None
+    timeoutSeconds: 10
+    reinvocationPolicy: Never
+    rules:
+      - apiGroups:
+          - dns.networking.miloapis.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - dnsrecordsets
+        scope: "*"

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,7 +11,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /mutate-dns-networking-miloapis-com-v1alpha1-dnsrecordset
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: mdnsrecordset.kb.io
   rules:
   - apiGroups:

--- a/docs/enhancements/activity-integration.md
+++ b/docs/enhancements/activity-integration.md
@@ -104,6 +104,8 @@ The Activity Service translates audit logs and Kubernetes events into human-read
 
 Helpers live in `internal/display`. The webhook looks up the parent `DNSZone` to build the FQDN; if the zone is missing, annotations are left unset and policy fallbacks use `spec.records[0].name`.
 
+Admission uses `failurePolicy: Ignore` so a missing webhook server degrades activity FQDNs instead of blocking DNSRecordSet writes. Cross-cluster registration for Datum control planes ships in `config/components/admission-webhooks` (OCI path `components/admission-webhooks`), versioned with the manager image (see that directory's README). Same-cluster kind/e2e packaging stays under `config/webhook/`.
+
 ### Data Sources
 
 Activities are generated from two sources:
@@ -142,6 +144,9 @@ config/milo/
       dnszone-policy.yaml
       dnsrecordset-policy.yaml
       testdata/                 # Fixture notes for policy CEL tests
+config/components/
+  admission-webhooks/         # Cross-cluster MWC (OCI path for control-plane Flux)
+config/webhook/               # Same-cluster Service + MWC (kind / replicator)
 internal/display/             # FQDN / display-value helpers
 internal/webhook/             # Mutating webhook for display annotations
 internal/activitypolicy/      # Policy structure + CEL match tests
@@ -225,7 +230,7 @@ Use admission webhooks to intercept changes and create activities.
 **Pros:** Real-time, guaranteed delivery
 **Cons:** Adds latency to API calls, single point of failure
 
-We use ActivityPolicy + Events for activity generation. A **mutating** webhook is used only to stamp display annotations at admission (not to create Activity objects), so create audits see the FQDN without redesigning audit plumbing.
+We use ActivityPolicy + Events for activity generation. A **mutating** webhook is used only to stamp display annotations at admission (not to create Activity objects), so create audits see the FQDN without redesigning audit plumbing. Registration for control-plane environments must come from the `dns-operator-kustomize` OCI path `components/admission-webhooks` (same semver as the manager image), not a hand-authored MWC in infra.
 
 ---
 

--- a/internal/webhook/dnsrecordset_mutating.go
+++ b/internal/webhook/dnsrecordset_mutating.go
@@ -2,7 +2,7 @@
 
 // Package webhook provides admission webhooks for DNS resources.
 //
-// +kubebuilder:webhook:path=/mutate-dns-networking-miloapis-com-v1alpha1-dnsrecordset,mutating=true,failurePolicy=fail,sideEffects=None,groups=dns.networking.miloapis.com,resources=dnsrecordsets,verbs=create;update,versions=v1alpha1,name=mdnsrecordset.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-dns-networking-miloapis-com-v1alpha1-dnsrecordset,mutating=true,failurePolicy=ignore,sideEffects=None,groups=dns.networking.miloapis.com,resources=dnsrecordsets,verbs=create;update,versions=v1alpha1,name=mdnsrecordset.kb.io,admissionReviewVersions=v1
 package webhook
 
 import (


### PR DESCRIPTION
## Summary

Infra previously registered the DNSRecordSet mutating webhook on the control-plane apiserver while production could still run an older dns-operator image with no webhook server. With `failurePolicy: Fail`, that skew blocked every DNSRecordSet write for about an hour ([infra#3688](https://github.com/datum-cloud/infra/issues/3688)).

This puts the MutatingWebhookConfiguration in `dns-operator-kustomize` at `components/admission-webhooks`, so a tag without a webhook server cannot carry a registration Flux can apply (for example `v0.6.4` has no `config/webhook` at all). The MWC points at `dns-operator-webhook-service` / `datum-dns-system` with no kustomize namespace transformer, so Flux `targetNamespace` cannot rewrite the Service namespace. Same-cluster kind/replicator packaging under `config/webhook/` keeps working, and both paths use `failurePolicy: Ignore` so a missing server degrades activity FQDNs instead of taking down writes.

Infra should re-enable admission with a thin Flux Kustomization pointing at this OCI path (same `OCIRepository` semver as manager), not a hand-authored MWC. Service and TLS mounts stay as cluster glue.

## Test plan

- [x] `kustomize build config/components/admission-webhooks` shows MWC with `Ignore` and `datum-dns-system` Service ref
- [x] `kustomize build config/overlays/replicator` includes webhook Service/MWC with `Ignore`
- [x] `go test ./internal/webhook/...`
- [ ] After merge + release: infra Flux KS consumes `path: components/admission-webhooks` from the same OCI tag as manager
- [ ] Staging create still succeeds if the webhook is unreachable (Ignore)

Closes #69

Related to #62