### PR TITLE
fix: Make DNS activity summaries name the record type

### DIFF
--- a/config/milo/activity/policies/dnsrecordset-policy.yaml
+++ b/config/milo/activity/policies/dnsrecordset-policy.yaml
@@ -6,12 +6,13 @@
 # Audit rules handle CRUD operations captured by the Kubernetes API server audit log.
 # Event rules handle async controller outcomes (programming failures).
 #
-# Design principles:
+# Design principles (issue #62):
+# - One readable line: who did what to which DNS name
+# - Always include the record type (A, CNAME, TXT, …) in human summaries
 # - Use FQDNs (www.example.com) as display text, not resource names
-# - Show record values (IPs, CNAME targets, MX hosts) where available
+# - Show record values (IPs, CNAME targets, MX hosts, TXT content) where available
 # - Accurate create / update / delete language ("added", "updated", "deleted")
-# - Type-specific phrasing for common record types
-# - Prefer display-name annotations (stamped at admission by mutating webhook)
+# - Prefer display-name / display-value annotations (stamped at admission)
 # - Fallback to relative owner name from spec.records when annotations are absent
 # - Exclude system components (system:*) from human audit rules
 # - Update rules read recordType from responseObject (portal PATCHes omit it on request)
@@ -29,31 +30,31 @@ spec:
     # ----- CREATE RULES (type-specific with display annotations) -----
     - name: create-a-aaaa
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType in ['A', 'AAAA'] && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
-      summary: "{{ actor }} added {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} pointing to {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
+      summary: "{{ actor }} added {{ audit.requestObject.spec.recordType }} record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} pointing to {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     - name: create-cname
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'CNAME' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
-      summary: "{{ actor }} added {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} as an alias for {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
+      summary: "{{ actor }} added CNAME record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} as an alias for {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     - name: create-alias
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'ALIAS' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
-      summary: "{{ actor }} added {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} as an alias for {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
+      summary: "{{ actor }} added ALIAS record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} as an alias for {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     - name: create-mx
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'MX' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
-      summary: "{{ actor }} configured mail for {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} using {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
+      summary: "{{ actor }} added MX record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} using {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     - name: create-txt
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'TXT' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
-      summary: "{{ actor }} added TXT record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }}"
+      summary: "{{ actor }} added TXT record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} with {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     - name: create-ns
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.requestObject.spec) && audit.requestObject.spec.recordType == 'NS' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
-      summary: "{{ actor }} added nameservers for {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }}"
+      summary: "{{ actor }} added NS record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} with nameservers {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     - name: create-other-annotated
       match: "!audit.user.username.startsWith('system:') && audit.verb == 'create' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations && has(audit.requestObject.spec)"
-      summary: "{{ actor }} added {{ audit.requestObject.spec.recordType }} record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }}"
+      summary: "{{ actor }} added {{ audit.requestObject.spec.recordType }} record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} with {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     # Create with spec but no display annotations: include relative owner name for searchability
     - name: create-from-request
@@ -86,15 +87,31 @@ spec:
     # All update rules require requestObject.spec so metadata-only patches are ignored.
     - name: update-a-aaaa
       match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.responseObject.spec) && audit.responseObject.spec.recordType in ['A', 'AAAA'] && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
-      summary: "{{ actor }} updated {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} to point to {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
+      summary: "{{ actor }} updated {{ audit.responseObject.spec.recordType }} record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} to point to {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     - name: update-cname
       match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.responseObject.spec) && audit.responseObject.spec.recordType == 'CNAME' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
-      summary: "{{ actor }} updated {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} to alias {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
+      summary: "{{ actor }} updated CNAME record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} as an alias for {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
+
+    - name: update-alias
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.responseObject.spec) && audit.responseObject.spec.recordType == 'ALIAS' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      summary: "{{ actor }} updated ALIAS record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} as an alias for {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
+
+    - name: update-mx
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.responseObject.spec) && audit.responseObject.spec.recordType == 'MX' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      summary: "{{ actor }} updated MX record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} to use {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
+
+    - name: update-txt
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.responseObject.spec) && audit.responseObject.spec.recordType == 'TXT' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      summary: "{{ actor }} updated TXT record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} to {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
+
+    - name: update-ns
+      match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.responseObject.spec) && audit.responseObject.spec.recordType == 'NS' && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
+      summary: "{{ actor }} updated NS record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} to nameservers {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     - name: update-other-annotated
       match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.responseObject.spec) && has(audit.responseObject.metadata.annotations) && 'dns.networking.miloapis.com/display-name' in audit.responseObject.metadata.annotations"
-      summary: "{{ actor }} updated {{ audit.responseObject.spec.recordType }} record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }}"
+      summary: "{{ actor }} updated {{ audit.responseObject.spec.recordType }} record {{ link(audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-name'], audit.objectRef) }} to {{ audit.responseObject.metadata.annotations['dns.networking.miloapis.com/display-value'] }}"
 
     - name: update-from-response
       match: "!audit.user.username.startsWith('system:') && audit.verb in ['update', 'patch'] && !has(audit.objectRef.subresource) && has(audit.requestObject.spec) && has(audit.responseObject.spec) && has(audit.responseObject.spec.records) && size(audit.responseObject.spec.records) > 0"

--- a/docs/enhancements/activity-integration.md
+++ b/docs/enhancements/activity-integration.md
@@ -44,21 +44,21 @@ Activities should use human-friendly display names (e.g., "example.com" not "exa
 | 10:00:01 | Zone example.com is waiting for dependencies |
 | 10:00:02 | Zone example.com is now active |
 | 10:00:05 | Zone example.com is ready with default SOA and NS records |
-| 10:01:00 | user@example.com added www.example.com pointing to 192.0.2.10 |
+| 10:01:00 | user@example.com added A record www.example.com pointing to 192.0.2.10 |
 | 10:01:02 | www.example.com is now resolving to 192.0.2.10 |
-| 10:02:00 | user@example.com added api.example.com as an alias for api.internal.example.com |
+| 10:02:00 | user@example.com added CNAME record api.example.com as an alias for api.internal.example.com |
 | 10:02:02 | api.example.com is now resolving to api.internal.example.com |
-| 10:03:00 | user@example.com configured mail for example.com to use mail.example.com and mail2.example.com |
-| 10:04:00 | user@example.com added www.example.com pointing to 192.0.2.20 |
+| 10:03:00 | user@example.com added MX record example.com using 10 mail.example.com, 20 mail2.example.com |
+| 10:04:00 | user@example.com updated A record www.example.com to point to 192.0.2.20 |
 | 10:04:01 | www.example.com pointing to 192.0.2.20 won't take effect because another record already controls this name |
-| 10:05:00 | user@example.com deleted www.example.com pointing to 192.0.2.10 |
+| 10:05:00 | user@example.com deleted A record www.example.com |
 | 10:05:01 | www.example.com is now resolving to 192.0.2.20 |
 
 ### Error Scenario
 
 | Timestamp | Activity |
 |-----------|----------|
-| 10:00:00 | user@example.com added www.example.com pointing to 192.0.2.10 |
+| 10:00:00 | user@example.com added A record www.example.com pointing to 192.0.2.10 |
 | 10:00:01 | www.example.com is waiting for zone to be ready |
 | 10:00:05 | Failed to apply www.example.com |
 | 10:00:10 | www.example.com is now resolving to 192.0.2.10 |

--- a/internal/activitypolicy/dnsrecordset_policy_test.go
+++ b/internal/activitypolicy/dnsrecordset_policy_test.go
@@ -113,6 +113,52 @@ func TestDNSRecordSetPolicy_Structure(t *testing.T) {
 	if !strings.Contains(createTXT, "display-name") {
 		t.Errorf("create-txt must include display-name hostname, got: %s", createTXT)
 	}
+	if !strings.Contains(createTXT, "TXT record") {
+		t.Errorf("create-txt must name the record type, got: %s", createTXT)
+	}
+	if !strings.Contains(createTXT, "display-value") {
+		t.Errorf("create-txt must include display-value for searchability, got: %s", createTXT)
+	}
+
+	createA := summaries["create-a-aaaa"]
+	if !strings.Contains(createA, "recordType") {
+		t.Errorf("create-a-aaaa must include A/AAAA recordType in summary, got: %s", createA)
+	}
+	if !strings.Contains(createA, "pointing to") {
+		t.Errorf("create-a-aaaa must include address phrasing, got: %s", createA)
+	}
+
+	updateA := summaries["update-a-aaaa"]
+	if !strings.Contains(updateA, "responseObject.spec.recordType") {
+		t.Errorf("update-a-aaaa must include A/AAAA recordType in summary, got: %s", updateA)
+	}
+
+	createCNAME := summaries["create-cname"]
+	if !strings.Contains(createCNAME, "CNAME record") {
+		t.Errorf("create-cname must name the record type, got: %s", createCNAME)
+	}
+	createALIAS := summaries["create-alias"]
+	if !strings.Contains(createALIAS, "ALIAS record") {
+		t.Errorf("create-alias must name the record type (distinct from CNAME), got: %s", createALIAS)
+	}
+	createMX := summaries["create-mx"]
+	if !strings.Contains(createMX, "MX record") {
+		t.Errorf("create-mx must name the record type, got: %s", createMX)
+	}
+	createNS := summaries["create-ns"]
+	if !strings.Contains(createNS, "NS record") {
+		t.Errorf("create-ns must name the record type, got: %s", createNS)
+	}
+
+	for _, name := range []string{"update-cname", "update-alias", "update-mx", "update-txt", "update-ns"} {
+		s, ok := summaries[name]
+		if !ok {
+			t.Fatalf("missing typed update rule %q", name)
+		}
+		if !strings.Contains(s, "display-value") {
+			t.Errorf("%s must include display-value, got: %s", name, s)
+		}
+	}
 
 	createFromReq := summaries["create-from-request"]
 	if !strings.Contains(createFromReq, "records[0].name") {


### PR DESCRIPTION
## Summary

- Audits and hardens DNSRecordSet ActivityPolicy phrasing for [#62](https://github.com/datum-cloud/dns-operator/issues/62)
- Human create/update lines now always include the **record type** (A/AAAA, CNAME, ALIAS, MX, TXT, NS, …) plus hostname and value where we have `display-*` annotations
- Adds typed update rules for ALIAS / MX / TXT / NS (previously fell through to a type-only “updated …” without the new value)
- Updates enhancement examples + policy structure tests

### Before → after (examples)

| Type | Before | After |
|------|--------|-------|
| A create | `added matthewjenkinson-demos.dev pointing to 192.168.1.1` | `added A record matthewjenkinson-demos.dev pointing to 192.168.1.1` |
| A update | `updated … to point to …` | `updated A record … to point to …` |
| CNAME | `added testing… as an alias for …` | `added CNAME record testing… as an alias for …` |
| ALIAS | same wording as CNAME | `added ALIAS record …` (distinct) |
| MX | `configured mail for … using …` | `added MX record … using …` |
| TXT | `added TXT record _dmarc…` | `added TXT record _dmarc… with "v=DMARC1…"` |
| NS | `added nameservers for …` | `added NS record … with nameservers …` |

Deletes were already `deleted TYPE record FQDN` and are unchanged.

## Test plan

- [x] `go test ./internal/activitypolicy/...`
- [ ] After merge + rollout: create/update A and CNAME on staging/prod and confirm Human activity includes type + FQDN + value
- [ ] Spot-check TXT (_dmarc) create includes truncated value for search

Related to #62